### PR TITLE
Don't allow deleting the last WebAuthn credential

### DIFF
--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -141,7 +141,8 @@ enum GetUserErr {
 
 enum UpdateUserErr {
 	NOT_EXISTS = "NOT_EXISTS",
-	DB_ERR = "DB_ERR"
+	DB_ERR = "DB_ERR",
+	LAST_WEBAUTHN_CREDENTIAL = "LAST_WEBAUTHN_CREDENTIAL",
 }
 
 enum UpdateFcmError {
@@ -347,16 +348,34 @@ async function updateWebauthnCredential(credential: WebauthnCredentialEntity, up
 
 async function deleteWebauthnCredential(user: UserEntity, credentialUuid: string): Promise<Result<{}, UpdateUserErr>> {
 	try {
-		const res = await webauthnCredentialRepository.createQueryBuilder()
-			.delete()
-			.from(WebauthnCredentialEntity)
-			.where({ user, id: credentialUuid })
-			.execute();
-		if (res.affected > 0) {
-			return Ok({});
-		} else if (res.affected === 0) {
-			return Err(UpdateUserErr.NOT_EXISTS);
-		}
+
+		return await userRepository.manager.transaction(async (manager) => {
+			const userRes = await manager.findOne(UserEntity, { where: { did: user.did }});
+			if (!userRes) {
+				return Err(UpdateUserErr.NOT_EXISTS);
+			}
+
+			const numCredentials = await manager.createQueryBuilder()
+				.select()
+				.from(WebauthnCredentialEntity, "cred")
+				.where({ user })
+				.getCount();
+			if (numCredentials < 2) {
+				return Err(UpdateUserErr.LAST_WEBAUTHN_CREDENTIAL);
+			}
+
+			const res = await manager.createQueryBuilder()
+				.delete()
+				.from(WebauthnCredentialEntity)
+				.where({ user, id: credentialUuid })
+				.execute();
+			if (res.affected > 0) {
+				return Ok({});
+			} else if (res.affected === 0) {
+				return Err(UpdateUserErr.NOT_EXISTS);
+			}
+		});
+
 	} catch (e) {
 		console.log(e);
 		return Err(UpdateUserErr.DB_ERR);

--- a/src/routers/user.router.ts
+++ b/src/routers/user.router.ts
@@ -401,6 +401,10 @@ userController.delete('/webauthn/credential/:id', async (req: Request, res: Resp
 	} else {
 		if (deleteRes.val === UpdateUserErr.NOT_EXISTS) {
 			res.status(404).send();
+
+		} else if (deleteRes.val === UpdateUserErr.LAST_WEBAUTHN_CREDENTIAL) {
+			res.status(409).send();
+
 		} else {
 			res.status(500).send();
 		}


### PR DESCRIPTION
This is an extra safety net, in addition to the frontend not displaying the delete option for the currently logged-in credential.