### PR TITLE
Optimize dev Dockerfile for rebuild speed and readonly filesystem

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,9 @@
+.env
+.git
+.gitattributes
+.gitignore
 .npmrc.template
-node_modules
-dist
 .vscode
+README.md
+dist
+node_modules

--- a/development.Dockerfile
+++ b/development.Dockerfile
@@ -3,7 +3,7 @@ FROM node:16-bullseye-slim as dependencies
 WORKDIR /dependencies
 
 # Install dependencies first so rebuild of these layers is only needed when dependencies change
-COPY package.json yarn.lock .npmrc .
+COPY package.json yarn.lock .npmrc ./
 RUN yarn cache clean && yarn install --frozen-lockfile
 
 
@@ -12,8 +12,8 @@ FROM node:16-bullseye-slim as cli-dependencies
 WORKDIR /dependencies
 
 # Install dependencies first so rebuild of these layers is only needed when dependencies change
-COPY cli/package.json cli/yarn.lock .
-RUN --mount=type=secret,id=npmrc,required=true,target=./.npmrc,uid=1000 \
+COPY cli/package.json cli/yarn.lock ./
+RUN --mount=type=secret,id=wallet-backend-server-npmrc,required=true,target=./.npmrc,uid=1000 \
     yarn cache clean && yarn install --frozen-lockfile
 
 

--- a/development.Dockerfile
+++ b/development.Dockerfile
@@ -1,20 +1,34 @@
-FROM node:16-bullseye-slim
-WORKDIR /home/node/app
+FROM node:16-bullseye-slim as dependencies
 
-# Copy package.json and yarn.lock and npmrc to the container
-COPY package.json yarn.lock .npmrc ./
-# RUN apt update -y && apt install python3 -y
+WORKDIR /dependencies
 
-RUN mkdir -p node_modules
+# Install dependencies first so rebuild of these layers is only needed when dependencies change
+COPY package.json yarn.lock .npmrc .
 RUN yarn cache clean && yarn install --frozen-lockfile
 
+
+FROM node:16-bullseye-slim as cli-dependencies
+
+WORKDIR /dependencies
+
+# Install dependencies first so rebuild of these layers is only needed when dependencies change
+COPY cli/package.json cli/yarn.lock .
+RUN --mount=type=secret,id=npmrc,required=true,target=./.npmrc,uid=1000 \
+    yarn cache clean && yarn install --frozen-lockfile
+
+
+FROM node:16-bullseye-slim as development
+
+COPY --from=cli-dependencies /dependencies/node_modules /cli_node_modules
+
+ENV NODE_PATH=/node_modules
+COPY --from=dependencies /dependencies/node_modules /node_modules
+
+WORKDIR /app
 ENV NODE_ENV development
+CMD ["yarn", "dev-docker"]
 
-RUN mkdir -p dist
-RUN chown -R node:node  /home/node/app/node_modules
-RUN chown -R node:node  /home/node/app/dist
+# Set user last so everything is readonly by default
 USER node
-CMD ["yarn", "dev"]
 
-# Copy the rest of the application code to the container
-COPY --chown=node:node . .
+# Don't need the rest of the sources since they'll be mounted from host

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "rm -rf dist && npx tsc",
     "dev": "nodemon --config nodemon.json --exec \"npx tsc && yarn start\"",
-    "dev-docker": "nodemon --config nodemon.json --exec \"npx tsc --outdir /dist && yarn start-docker\"",
+    "dev-docker": "npx nodemon --config nodemon.json --exec \"npx tsc --outdir /dist && yarn start-docker\"",
     "start": "node -r source-map-support/register dist/src/app.js",
     "start-docker": "node -r source-map-support/register /dist/src/app.js",
     "typeorm": "typeorm-ts-node-commonjs -d src/AppDataSource.ts",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "rm -rf dist && npx tsc",
     "dev": "nodemon --config nodemon.json --exec \"npx tsc && yarn start\"",
+    "dev-docker": "nodemon --config nodemon.json --exec \"npx tsc --outdir /dist && yarn start-docker\"",
     "start": "node -r source-map-support/register dist/src/app.js",
+    "start-docker": "node -r source-map-support/register /dist/src/app.js",
     "typeorm": "typeorm-ts-node-commonjs -d src/AppDataSource.ts",
     "typeorm-raw": "typeorm-ts-node-commonjs"
   },


### PR DESCRIPTION
This restructures the development Dockerfile to put `node_modules` in a readonly filesystem and to make maximal use of the Docker build cache. This makes the installed dependencies consistently determined by the Docker image alone, independent of any runtime state held in volumes. The optimized layer order also enables using `docker-compose up --build` in the parent project to automatically rebuild the image on any changes to dependencies.

This also moves `dist/` outside of the sources directory that will be mounted from the host at runtime, and instead expects a tmpfs mounted at `/dist`. This prevents any issues with permission clashes between the container and the host.