### PR TITLE
Update branding of WebAuthn RP name

### DIFF
--- a/config/config.template.ts
+++ b/config/config.template.ts
@@ -16,7 +16,7 @@ export = {
 		origin: "WEBAUTHN_ORIGIN",
 		rp: {
 			id: "WEBAUTHN_RP_ID",
-			name: "Digital Wallet demo",
+			name: "wwWallet demo",
 		},
 	},
 	alg: "EdDSA",


### PR DESCRIPTION
`rp.name` is a human-friendly label for the web service requesting WebAuthn credential creation. The browser may show this label to the user during credential creation and/or in the authenticator's credential management interface (few or no browsers currently do, though - most just show `rp.id` which is the service's domain name).

This will not affect existing credentials and has no security impact; this value is meant only for display.