### PR TITLE
Wrap all account deletion operations in one database transaction

### DIFF
--- a/src/entities/FcmToken.entity.ts
+++ b/src/entities/FcmToken.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn, Repository } from "typeorm";
+import { Column, Entity, EntityManager, ManyToOne, PrimaryGeneratedColumn, Repository } from "typeorm";
 import { UserEntity } from "./user.entity";
 import AppDataSource from "../AppDataSource";
 import { Err, Ok, Result } from "ts-results";
@@ -20,9 +20,9 @@ const fcmTokenRepository: Repository<FcmTokenEntity> = AppDataSource.getReposito
 enum DeleteFcmTokenErr {
 	DB_ERR = "DB_ERR"
 }
-async function deleteAllFcmTokensForUser(did: string): Promise<Result<{}, DeleteFcmTokenErr>> {
+async function deleteAllFcmTokensForUser(did: string, options?: { entityManager?: EntityManager }): Promise<Result<{}, DeleteFcmTokenErr>> {
 	try {
-		return await fcmTokenRepository.manager.transaction(async (manager) => {
+		return await (options?.entityManager || fcmTokenRepository.manager).transaction(async (manager) => {
 			const tokens = await manager.find(FcmTokenEntity, { where: { user: { did: did } } });
 			await manager.remove(tokens);
 			return Ok({});

--- a/src/entities/common.entity.ts
+++ b/src/entities/common.entity.ts
@@ -1,0 +1,24 @@
+import { EntityManager } from "typeorm"
+
+import AppDataSource from "../AppDataSource";
+
+/**
+	* Run the provided callback in a database transaction. The `entityManager` can
+	* be passed as an argument down the call stack to make the transaction cover
+	* any database operation that can take the `EntityManager` to use as an
+	* argument.
+	*
+	* This function accepts `Err` `Result`s to signal that the transaction should
+	* be aborted, in addition to the conventional signals of throwing an exception
+	* or returning a rejected `Promise`.
+	*/
+export async function runTransaction<T>(runInTransaction: (entityManager: EntityManager) => Promise<T>): Promise<T> {
+	return await AppDataSource.manager.transaction(async (entityManager) => {
+		const result = await runInTransaction(entityManager);
+		if ("err" in result && "val" in result) {
+			if (result["err"]) {
+				return Promise.reject(result["val"]);
+			}
+		}
+	});
+}

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -215,9 +215,9 @@ async function getUserByDID(did: string): Promise<Result<UserEntity, GetUserErr>
 	}
 }
 
-async function deleteUserByDID(did: string): Promise<Result<{}, DeleteUserErr>> {
+async function deleteUserByDID(did: string, options?: { entityManager: EntityManager }): Promise<Result<{}, DeleteUserErr>> {
 	try {
-		return await userRepository.manager.transaction(async (manager) => {
+		return await (options?.entityManager || userRepository.manager).transaction(async (manager) => {
 			const userRes = await manager.findOne(UserEntity, { where: { did: did }});
 
 			await manager.delete(WebauthnCredentialEntity, {

--- a/src/routers/user.router.ts
+++ b/src/routers/user.router.ts
@@ -4,6 +4,7 @@ import * as uuid from 'uuid';
 import crypto from 'node:crypto';
 import * as SimpleWebauthn from '@simplewebauthn/server';
 import base64url from 'base64url';
+import { EntityManager } from "typeorm"
 
 import config from '../../config';
 import { CreateUser, createUser, deleteUserByDID, deleteWebauthnCredential, getUserByCredentials, getUserByDID, getUserByWebauthnCredential, newWebauthnCredentialEntity, updateUserByDID, UpdateUserErr, updateWebauthnCredential, updateWebauthnCredentialById, UserEntity } from '../entities/user.entity';
@@ -15,9 +16,11 @@ import * as scrypt from "../scrypt";
 import { appContainer } from '../services/inversify.config';
 import { RegistrationParams, WalletKeystoreManager } from '../services/interfaces';
 import { TYPES } from '../services/types';
+import { runTransaction } from '../entities/common.entity';
 import { deleteAllFcmTokensForUser, FcmTokenEntity } from '../entities/FcmToken.entity';
 import { deleteAllPresentationsWithHolderDID } from '../entities/VerifiablePresentation.entity';
 import { deleteAllCredentialsWithHolderDID } from '../entities/VerifiableCredential.entity';
+import { Err, Ok, Result } from 'ts-results';
 
 
 
@@ -468,30 +471,26 @@ userController.post('/webauthn/credential/:id/delete', async (req: Request, res:
 
 userController.delete('/', async (req: Request, res: Response) => {
 	const userDID = req.user.did;
-	const [ fcmTokenDeletionRes, credentialsDeletionRes, presentationsDeletionRes ] = await Promise.all([
-		deleteAllFcmTokensForUser(userDID),
-		deleteAllCredentialsWithHolderDID(userDID),
-		deleteAllPresentationsWithHolderDID(userDID)
-	]);
+	try {
+		const result = await runTransaction(async (entityManager: EntityManager) => {
+			// Note: this executes all four branches before checking if any failed.
+			// ts-results does not seem to provide an async-optimized version of Result.all(),
+			// and it turned out nontrivial to write one that preserves the Ok and Err types like Result.all() does.
+			return Result.all(
+				await deleteAllFcmTokensForUser(userDID, { entityManager }),
+				await deleteAllCredentialsWithHolderDID(userDID, { entityManager }),
+				await deleteAllPresentationsWithHolderDID(userDID, { entityManager }),
+				await deleteUserByDID(userDID, { entityManager }),
+			);
+		});
 
-	if (fcmTokenDeletionRes.err) {
-		return res.status(400).send({ result: fcmTokenDeletionRes.val })
-	}
-
-	if (credentialsDeletionRes.err) {
-		return res.status(400).send({ result: credentialsDeletionRes.val })
-	}
-
-	if (presentationsDeletionRes.err) {
-		return res.status(400).send({ result: presentationsDeletionRes.val })
-	}
-
-	const result = await deleteUserByDID(userDID);
-	if (!result.err) {
-		return res.send({ result: "DELETED" });
-	}
-	else {
-		return res.status(400).send({ result: result.val })
+		if (result.err) {
+			return res.status(400).send({ result: result.val })
+		} else {
+			return res.send({ result: "DELETED" });
+		}
+	} catch (e) {
+		return res.status(400).send({ result: e })
 	}
 });
 // /**


### PR DESCRIPTION
(This would merge into PR #46, not directly into master)

This refactors the various delete operations to accept an optional `EntityManager` argument, and using that to perform the query if it is provided. This allows for injecting a transaction manager to make an overarching transaction cover several disparate database operations.