### PR TITLE
Change type of privateData from string to Buffer

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -10,7 +10,7 @@ import { communicationHandlerRouter } from './routers/communicationHandler.route
 import { storageRouter } from './routers/storage.router';
 import { legalPersonRouter } from './routers/legal_person.router';
 import verifiersRouter from './routers/verifiers.router';
-import { reviverTaggedBase64UrlToBuffer } from './util/util';
+import { replacerBufferToTaggedBase64Url, reviverTaggedBase64UrlToBuffer } from './util/util';
 import * as WebSocket from 'ws';
 import http from 'http';
 import { appContainer } from './services/inversify.config';
@@ -27,6 +27,7 @@ const app: Express = express();
 app.use(cookieParser());
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json({ reviver: reviverTaggedBase64UrlToBuffer }));
+app.set('json replacer', replacerBufferToTaggedBase64Url);
 
 app.use(express.static('public'));
 // __dirname is "/path/to/dist/src"

--- a/src/routers/user.router.ts
+++ b/src/routers/user.router.ts
@@ -8,7 +8,7 @@ import { EntityManager } from "typeorm"
 
 import config from '../../config';
 import { CreateUser, createUser, deleteUserByDID, deleteWebauthnCredential, getUserByCredentials, getUserByDID, getUserByWebauthnCredential, newWebauthnCredentialEntity, updateUserByDID, UpdateUserErr, updateWebauthnCredential, updateWebauthnCredentialById, UserEntity } from '../entities/user.entity';
-import { jsonParseTaggedBinary, jsonStringifyTaggedBinary } from '../util/util';
+import { jsonParseTaggedBinary } from '../util/util';
 import { AuthMiddleware } from '../middlewares/auth.middleware';
 import { ChallengeErr, createChallenge, popChallenge } from '../entities/WebauthnChallenge.entity';
 import * as webauthn from '../webauthn';
@@ -125,10 +125,10 @@ noAuthUserController.post('/register-webauthn-begin', async (req: Request, res: 
 		},
 	});
 
-	res.status(200).send(jsonStringifyTaggedBinary({
+	res.status(200).send({
 		challengeId: challenge.id,
 		createOptions,
-	}));
+	});
 });
 
 noAuthUserController.post('/register-webauthn-finish', async (req: Request, res: Response) => {
@@ -208,10 +208,10 @@ noAuthUserController.post('/login-webauthn-begin', async (req: Request, res: Res
 	const challenge = challengeRes.unwrap();
 	const getOptions = webauthn.makeGetOptions({ challenge: challenge.challenge });
 
-	res.status(200).send(jsonStringifyTaggedBinary({
+	res.status(200).send({
 		challengeId: challenge.id,
 		getOptions,
-	}));
+	});
 });
 
 noAuthUserController.post('/login-webauthn-finish', async (req: Request, res: Response) => {
@@ -301,7 +301,7 @@ userController.get('/account-info', async (req: Request, res: Response) => {
 
 	const keys = jsonParseTaggedBinary(user.keys.toString());
 
-	res.status(200).send(jsonStringifyTaggedBinary({
+	res.status(200).send({
 		username: user.username,
 		displayName: user.displayName,
 		did: user.did,
@@ -316,7 +316,7 @@ userController.get('/account-info', async (req: Request, res: Response) => {
 			nickname: cred.nickname,
 			prfCapable: cred.prfCapable,
 		})),
-	}));
+	});
 })
 
 userController.post('/webauthn/register-begin', async (req: Request, res: Response) => {
@@ -349,11 +349,11 @@ userController.post('/webauthn/register-begin', async (req: Request, res: Respon
 		},
 	});
 
-	res.status(200).send(jsonStringifyTaggedBinary({
+	res.status(200).send({
 		username: user.username,
 		challengeId: challenge.id,
 		createOptions,
-	}));
+	});
 });
 
 userController.post('/webauthn/register-finish', async (req: Request, res: Response) => {
@@ -410,9 +410,9 @@ userController.post('/webauthn/register-finish', async (req: Request, res: Respo
 		});
 
 		if (updateUserRes.ok) {
-			res.status(200).send(jsonStringifyTaggedBinary({
+			res.status(200).send({
 				credentialId: credential.id
-			}));
+			});
 		} else {
 			res.status(500).send({});
 		}

--- a/src/services/interfaces.ts
+++ b/src/services/interfaces.ts
@@ -38,7 +38,7 @@ export type AdditionalKeystoreParameters = {
 export type RegistrationParams = {
 	fcm_token?: string;
 	keys?: WalletKey;
-	privateData?: any;
+	privateData?: Buffer;
 	displayName: string;
 }
 


### PR DESCRIPTION
Preliminary step towards resolving the "phase 0" laid out in https://github.com/wwWallet/wallet-ecosystem/issues/62.

The internal format of the opaque `privateData` should be up to the frontend alone, so there's no need for the server backend to care about any format conversions, other than making sure the binary data is unchanged. This simplifies things by reducing the number of format conversions that need to be made.

This is mutually dependent on this PR in wallet-frontend:
- https://github.com/wwWallet/wallet-frontend/pull/261