### PR TITLE
Fix issues with X-Private-Data-ETag header

### DIFF
--- a/src/routers/user.router.ts
+++ b/src/routers/user.router.ts
@@ -442,7 +442,7 @@ userController.post('/webauthn/register-finish', async (req: Request, res: Respo
 
 		if (updateUserRes.ok) {
 			res.status(200)
-				.header({ 'X-Private-Data-ETag': privateDataEtag(user.privateData) })
+				.header({ 'X-Private-Data-ETag': privateDataEtag(updateUserRes.val.privateData) })
 				.send({ credentialId: credential.id });
 		} else if (updateUserRes.val === UpdateUserErr.PRIVATE_DATA_CONFLICT) {
 			res.status(412)
@@ -495,7 +495,7 @@ userController.post('/webauthn/credential/:id/delete', async (req: Request, res:
 	const deleteRes = await deleteWebauthnCredential(user, req.params.id, updatePrivateData);
 	if (deleteRes.ok) {
 		res.status(204)
-			.header({ 'X-Private-Data-ETag': privateDataEtag(user.privateData) })
+			.header({ 'X-Private-Data-ETag': privateDataEtag(updatePrivateData.newValue) })
 			.send();
 	} else {
 		if (deleteRes.val === UpdateUserErr.NOT_EXISTS) {
@@ -506,7 +506,7 @@ userController.post('/webauthn/credential/:id/delete', async (req: Request, res:
 
 		} else if (deleteRes.val === UpdateUserErr.PRIVATE_DATA_CONFLICT) {
 			res.status(412)
-				.header({ 'X-Private-Data-ETag': privateDataEtag(user.privateData) })
+				.header({ 'X-Private-Data-ETag': privateDataEtag(updatePrivateData.newValue) })
 				.send();
 
 		} else {

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -68,9 +68,22 @@ export function checkedUpdate<T, U>(
 	tagFunc: (value: T) => U,
 	{ currentValue, newValue }: { currentValue: T, newValue: T },
 ): Result<T, void> {
-	if (tagFunc(currentValue) === expectTag) {
+	if (currentValue === newValue) {
+		// Change has already been applied (if T supports === equality)
 		return Ok(newValue);
+
 	} else {
+		const currentTag = tagFunc(currentValue)
+		if (currentTag === expectTag) {
+			// Expected change
+			return Ok(newValue);
+
+		} else {
+			if (currentTag === tagFunc(newValue)) {
+				// Change has already been applied (if T does not support === equality)
+				return Ok(newValue);
+			}
+		}
 		return Err.EMPTY;
 	}
 }


### PR DESCRIPTION
Apparently I didn't properly test #57 - attempting to register and/or delete multiple credentials in sequence would fail, because both the frontend and the backend failed to keep track of the correct ETag state.

Related: 
- https://github.com/wwWallet/wallet-frontend/pull/277