### PR TITLE
Rename UserEntity.webauthnUserHandle to uuid and use it instead of DID where possible

### DIFF
--- a/src/entities/FcmToken.entity.ts
+++ b/src/entities/FcmToken.entity.ts
@@ -1,5 +1,5 @@
-import { Column, Entity, EntityManager, ManyToOne, PrimaryGeneratedColumn, Repository } from "typeorm";
-import { UserEntity } from "./user.entity";
+import { Column, Entity, EntityManager, Equal, ManyToOne, PrimaryGeneratedColumn, Repository } from "typeorm";
+import { UserEntity, UserId } from "./user.entity";
 import AppDataSource from "../AppDataSource";
 import { Err, Ok, Result } from "ts-results";
 
@@ -20,10 +20,10 @@ const fcmTokenRepository: Repository<FcmTokenEntity> = AppDataSource.getReposito
 enum DeleteFcmTokenErr {
 	DB_ERR = "DB_ERR"
 }
-async function deleteAllFcmTokensForUser(did: string, options?: { entityManager?: EntityManager }): Promise<Result<{}, DeleteFcmTokenErr>> {
+async function deleteAllFcmTokensForUser(id: UserId, options?: { entityManager?: EntityManager }): Promise<Result<{}, DeleteFcmTokenErr>> {
 	try {
 		return await (options?.entityManager || fcmTokenRepository.manager).transaction(async (manager) => {
-			const tokens = await manager.find(FcmTokenEntity, { where: { user: { did: did } } });
+			const tokens = await manager.find(FcmTokenEntity, { where: { user: { uuid: Equal(id) } } });
 			await manager.remove(tokens);
 			return Ok({});
 		});

--- a/src/entities/WebauthnChallenge.entity.ts
+++ b/src/entities/WebauthnChallenge.entity.ts
@@ -2,6 +2,7 @@ import { Err, Ok, Result } from "ts-results";
 import { Entity, PrimaryColumn, Column, Repository} from "typeorm"
 import AppDataSource from "../AppDataSource";
 import crypto from "node:crypto";
+import { UserId } from "./user.entity";
 @Entity({ name: "webauthn_challenge" })
 class WebauthnChallengeEntity {
 	@PrimaryColumn()
@@ -10,9 +11,20 @@ class WebauthnChallengeEntity {
 	@Column({ nullable: false})
 	type: string;
 
-	// Explicit default to workaround a bug in typeorm: https://github.com/typeorm/typeorm/issues/3076#issuecomment-703128687
-	@Column({ nullable: true, default: () => "NULL", update: false })
-	userHandle?: string;
+	/**
+	 * This was renamed in PR (TBD).
+	 * We keep the old database column name for forward- and backwards compatibility between application and schema versions.
+	 */
+	@Column({
+		name: "userHandle",
+		type: "varchar",
+		length: 255,
+		nullable: true,
+		// Explicit default to workaround a bug in typeorm: https://github.com/typeorm/typeorm/issues/3076#issuecomment-703128687
+		default: () => "NULL",
+		transformer: { from: (id) => id && UserId.fromId(id), to: (userId: UserId) => userId?.id },
+	})
+	userId?: UserId;
 
 	@Column({ nullable: false })
 	challenge: Buffer;
@@ -29,7 +41,7 @@ const TIMEOUT_MILLISECONDS = 15 * 60 * 1000;
 
 type CreatedChallenge = {
 	id: string;
-	userHandle?: string;
+	userId?: UserId;
 	challenge: Buffer;
 	prfSalt?: Buffer;
 }
@@ -43,10 +55,10 @@ enum ChallengeErr {
 const challengeRepository: Repository<WebauthnChallengeEntity> = AppDataSource.getRepository(WebauthnChallengeEntity);
 
 
-async function createChallenge(type: "create" | "get", userHandle?: string, prfSalt?: Buffer): Promise<Result<CreatedChallenge, ChallengeErr>> {
+async function createChallenge(type: "create" | "get", userId?: UserId, prfSalt?: Buffer): Promise<Result<CreatedChallenge, ChallengeErr>> {
 	try {
 		const returnData = {
-			userHandle,
+			userId,
 			prfSalt,
 			id: crypto.randomUUID(),
 			challenge: crypto.randomBytes(32),

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -1,7 +1,8 @@
 import { Err, Ok, Result } from "ts-results";
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, OneToMany, Repository, Generated, EntityManager, DeepPartial, JoinColumn } from "typeorm"
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, OneToMany, Repository, EntityManager, DeepPartial, Generated } from "typeorm"
 import crypto from "node:crypto";
 import base64url from "base64url";
+import * as uuid from 'uuid';
 
 import AppDataSource from "../AppDataSource";
 import * as scrypt from "../scrypt";
@@ -24,11 +25,63 @@ export function privateDataEtag(privateData: Buffer): string {
 }
 
 
+// Duplicated in wallet-frontend
+export class UserId {
+	public readonly id: string;
+	private constructor(id: string) {
+		this.id = id;
+	}
+
+	public toString(): string {
+		return `UserId(this.id)`;
+	}
+
+	public toJSON(): string {
+		return this.id;
+	}
+
+	static generate(): UserId {
+		return new UserId(uuid.v4());
+	}
+
+	static fromId(id: string): UserId {
+		return new UserId(id);
+	}
+
+	static fromUserHandle(userHandle: Buffer): UserId {
+		return new UserId(userHandle.toString());
+	}
+
+	public asUserHandle(): Buffer {
+		return Buffer.from(this.id, "utf8");
+	}
+}
+
+
 @Entity({ name: "user" })
 class UserEntity {
-	@PrimaryGeneratedColumn()
-	id: number;
+	/**
+	 * This was obsoleted by PR (TBD).
+	 * We keep the table column for forward- and backwards compatibility between application and schema versions.
+	 * It still needs to be the primary ID in order for table relations to continue working.
+	 */
+	@Column({ primary: true, unique: true, nullable: false, update: false })
+	@Generated("increment")
+	private id: number;
 
+	/**
+	 * This was renamed in PR (TBD).
+	 * We keep the old database column name for forward- and backwards compatibility between application and schema versions.
+	 */
+	@Column({
+		unique: true,
+		nullable: false,
+		update: false,
+		name: "webauthnUserHandle",
+		transformer: { from: UserId.fromId, to: (userId: UserId) => userId.id },
+	})
+	@Generated("uuid")
+	uuid: UserId;
 
 	// Explicit default to workaround a bug in typeorm: https://github.com/typeorm/typeorm/issues/3076#issuecomment-703128687
 	@Column({ unique: true, nullable: true, default: () => "NULL" })
@@ -56,10 +109,6 @@ class UserEntity {
 	@Column({ type: "blob", nullable: false })
 	privateData: Buffer;
 
-	@Column({ nullable: false, update: false })
-	@Generated("uuid")
-	webauthnUserHandle: string;
-
 
 	@Column({ type: "enum" ,enum: WalletType, default: WalletType.DB })
 	walletType: WalletType;
@@ -85,8 +134,12 @@ class WebauthnCredentialEntity {
 	@Column({ nullable: false, update: false })
 	credentialId: Buffer;
 
-	@Column({ nullable: false, update: false })
-	userHandle: Buffer;
+	/**
+	 * This was obsoleted by PR (TBD).
+	 * We keep the table column for forward- and backwards compatibility between application and schema versions.
+	 */
+	@Column({ name: "userHandle", nullable: false, select: false, update: false })
+	_userHandle: Buffer;
 
 	// Explicit default to workaround a bug in typeorm: https://github.com/typeorm/typeorm/issues/3076#issuecomment-703128687
 	@Column({ nullable: true, default: () => "NULL" })
@@ -133,14 +186,13 @@ type CreateUser = {
 	passwordHash: string;
 	fcmToken: string;
 	privateData: Buffer;
-	webauthnUserHandle: string;
 } | {
+	uuid: UserId;
 	displayName: string,
 	did: string;
 	keys: Buffer;
 	fcmToken: string;
 	privateData: Buffer;
-	webauthnUserHandle: string;
 	webauthnCredentials: WebauthnCredentialEntity[];
 }
 
@@ -217,7 +269,7 @@ async function deleteUserByDID(did: string, options?: { entityManager: EntityMan
 			const userRes = await manager.findOne(UserEntity, { where: { did: did }});
 
 			await manager.delete(WebauthnCredentialEntity, {
-				user: { id: userRes.id }
+				user: { uuid: userRes.uuid }
 			});
 
 			await manager.delete(UserEntity, {
@@ -274,12 +326,12 @@ async function getUserByCredentials(username: string, password: string): Promise
 }
 
 
-async function getUserByWebauthnCredential(userHandle: string, credentialId: Buffer): Promise<Result<[UserEntity, WebauthnCredentialEntity], GetUserErr>> {
+async function getUserByWebauthnCredential(userId: UserId, credentialId: Buffer): Promise<Result<[UserEntity, WebauthnCredentialEntity], GetUserErr>> {
 	try {
-		console.log("getUserByWebauthnCredential", userHandle, base64url.encode(credentialId));
+		console.log("getUserByWebauthnCredential", userId, base64url.encode(credentialId));
 		const q = userRepository.createQueryBuilder("user")
 			.leftJoinAndSelect("user.webauthnCredentials", "credential")
-			.where("user.webauthnUserHandle = :userHandle", { userHandle })
+			.where("user.uuid = :uuid", { uuid: userId.id })
 			.andWhere("credential.credentialId = :credentialId", { credentialId });
 		console.log(q.getSql());
 		const userRes = await q.getOne();

--- a/src/middlewares/auth.middleware.ts
+++ b/src/middlewares/auth.middleware.ts
@@ -2,7 +2,7 @@ import { Request, Response, NextFunction } from "express";
 
 import { jwtVerify, SignJWT } from 'jose';
 import config from "../../config";
-import { getUserByDID, UserEntity } from "../entities/user.entity";
+import { getUserByDID, UserEntity, UserId } from "../entities/user.entity";
 
 
 type TokenPayloadVersion = 0;
@@ -16,6 +16,7 @@ type AppTokenPayload = {
 
 export type AppTokenUser = {
 	username: string;
+	id: UserId;
 	did: string;
 }
 
@@ -73,6 +74,7 @@ export function AuthMiddleware(req: Request, res: Response, next: NextFunction) 
 			req.user = {
 				username: userRes.val.username,
 				did,
+				id: userRes.val.uuid,
 			};
 			return next();
 		}

--- a/src/routers/communicationHandler.router.ts
+++ b/src/routers/communicationHandler.router.ts
@@ -44,7 +44,7 @@ communicationHandlerRouter.post('/handle', async (req, res) => {
 	if (generateAuthorizationRequestSchemaResult.success) {
 		try {
 			const { legal_person_did } = req.body;
-			const result = await openidForCredentialIssuanceService.generateAuthorizationRequestURL(req.user.did, null, legal_person_did);
+			const result = await openidForCredentialIssuanceService.generateAuthorizationRequestURL(req.user.id, null, legal_person_did);
 			console.log("Succesfully handled by generateAuthorizationRequestURL");
 			return res.send(result);
 		}
@@ -57,7 +57,7 @@ communicationHandlerRouter.post('/handle', async (req, res) => {
 			const {
 				url,
 			} = req.body;
-			const result = await openidForCredentialIssuanceService.generateAuthorizationRequestURL(req.user.did, url, null);
+			const result = await openidForCredentialIssuanceService.generateAuthorizationRequestURL(req.user.id, url, null);
 			console.log("Successfully handled by generateAuthorizationRequestURL");
 			return res.send(result);
 		}
@@ -74,7 +74,7 @@ communicationHandlerRouter.post('/handle', async (req, res) => {
 			if (!(new URL(url).searchParams.get("code"))) {
 				throw new Error("No code was provided");
 			}
-			const result = await openidForCredentialIssuanceService.handleAuthorizationResponse(req.user.did, url);
+			const result = await openidForCredentialIssuanceService.handleAuthorizationResponse(req.user.id, url);
 			if (result.ok) {
 				console.log("Successfully handled by handleAuthorizationResponse");
 				return res.send({});
@@ -90,7 +90,7 @@ communicationHandlerRouter.post('/handle', async (req, res) => {
 				user_pin
 			} = req.body;
 
-			const response = await openidForCredentialIssuanceService.requestCredentialsWithPreAuthorizedGrant(req.user.did, user_pin);
+			const response = await openidForCredentialIssuanceService.requestCredentialsWithPreAuthorizedGrant(req.user.id, user_pin);
 			console.log("Response = ", response)
 			if (response.error) {
 				return res.status(401).send({ error: response.error });
@@ -105,7 +105,7 @@ communicationHandlerRouter.post('/handle', async (req, res) => {
 	if (handleSIOPRequestResult.success) {
 		const { url, camera_was_used } = handleSIOPRequestResult.data;
 		try {
-			const outboundRequestResult = await openidForPresentationService.handleRequest(req.user.did, url, camera_was_used);
+			const outboundRequestResult = await openidForPresentationService.handleRequest(req.user.id, url, camera_was_used);
 			if (!outboundRequestResult.ok) {
 				if (outboundRequestResult.val == HandleOutboundRequestError.INSUFFICIENT_CREDENTIALS) {
 					return res.send({ error: HandleOutboundRequestError.INSUFFICIENT_CREDENTIALS });
@@ -144,7 +144,7 @@ communicationHandlerRouter.post('/handle', async (req, res) => {
 		const selection = new Map(Object.entries(verifiable_credentials_map)) as Map<string, string>;
 		console.log("Selection = ", verifiable_credentials_map)
 		try {
-			const result = await openidForPresentationService.sendResponse(req.user.did, selection);
+			const result = await openidForPresentationService.sendResponse(req.user.id, selection);
 
 			if (!result.ok) {
 				return res.send({ error: SendResponseError.SEND_RESPONSE_ERROR });

--- a/src/routers/user.router.ts
+++ b/src/routers/user.router.ts
@@ -6,7 +6,7 @@ import base64url from 'base64url';
 import { EntityManager } from "typeorm"
 
 import config from '../../config';
-import { CreateUser, createUser, deleteUserByDID, deleteWebauthnCredential, getUserByCredentials, getUserByDID, getUserByWebauthnCredential, GetUserErr, newWebauthnCredentialEntity, privateDataEtag, updateUserByDID, UpdateUserErr, updateWebauthnCredential, updateWebauthnCredentialById, UserEntity } from '../entities/user.entity';
+import { CreateUser, createUser, deleteUserByDID, deleteWebauthnCredential, getUserByCredentials, getUserByDID, getUserByWebauthnCredential, GetUserErr, newWebauthnCredentialEntity, privateDataEtag, updateUserByDID, UpdateUserErr, updateWebauthnCredential, updateWebauthnCredentialById, UserEntity, UserId } from '../entities/user.entity';
 import { checkedUpdate, EtagUpdate, jsonParseTaggedBinary } from '../util/util';
 import { AuthMiddleware, createAppToken } from '../middlewares/auth.middleware';
 import { ChallengeErr, createChallenge, popChallenge } from '../entities/WebauthnChallenge.entity';
@@ -36,24 +36,22 @@ noAuthUserController.use('/session', userController);
 
 
 async function initSession(user: UserEntity): Promise<{
-	id: number,
+	uuid: UserId,
 	did: string,
 	appToken: string,
 	username?: string,
 	displayName: string,
 	privateData: Buffer,
 	webauthnRpId: string,
-	webauthnUserHandle: string,
 }> {
 	return {
-		id: user.id,
+		uuid: user.uuid,
 		appToken: await createAppToken(user),
 		did: user.did,
 		displayName: user.displayName || user.username,
 		privateData: user.privateData,
 		username: user.username,
 		webauthnRpId: webauthn.getRpId(),
-		webauthnUserHandle: user.webauthnUserHandle,
 	};
 }
 
@@ -78,7 +76,6 @@ noAuthUserController.post('/register', async (req: Request, res: Response) => {
 		...walletInitializationResult.unwrap(),
 		username: username ? username : "",
 		passwordHash: passwordHash,
-		webauthnUserHandle: uuid.v4(),
 	};
 
 	const result = (await createUser(newUser));
@@ -119,7 +116,8 @@ noAuthUserController.post('/login/db-keys', async (req: Request, res: Response) 
 })
 
 noAuthUserController.post('/register-webauthn-begin', async (req: Request, res: Response) => {
-	const challengeRes = await createChallenge("create", uuid.v4());
+	const userId = UserId.generate();
+	const challengeRes = await createChallenge("create", userId);
 	if (challengeRes.err) {
 		res.status(500).send({});
 		return;
@@ -129,7 +127,7 @@ noAuthUserController.post('/register-webauthn-begin', async (req: Request, res: 
 	const createOptions = webauthn.makeCreateOptions({
 		challenge: challenge.challenge,
 		user: {
-			webauthnUserHandle: challenge.userHandle,
+			uuid: userId,
 			name: "",
 			displayName: "",
 		},
@@ -175,8 +173,7 @@ noAuthUserController.post('/register-webauthn-finish', async (req: Request, res:
 	});
 
 	if (verification.verified) {
-		const webauthnUserHandle = challenge.userHandle;
-		if (!webauthnUserHandle) {
+		if (!challenge.userId) {
 			res.status(500).send({});
 			return;
 		}
@@ -190,11 +187,11 @@ noAuthUserController.post('/register-webauthn-finish', async (req: Request, res:
 
 		const newUser: CreateUser = {
 			...walletInitializationResult.unwrap(),
-			webauthnUserHandle,
+			uuid: challenge.userId,
 			webauthnCredentials: [
 				newWebauthnCredentialEntity({
 					credentialId: credential.rawId,
-					userHandle: Buffer.from(webauthnUserHandle),
+					_userHandle: challenge.userId.asUserHandle(),
 					nickname: req.body.nickname,
 					publicKeyCose: Buffer.from(verification.registrationInfo.credentialPublicKey),
 					signatureCount: verification.registrationInfo.counter,
@@ -239,10 +236,10 @@ noAuthUserController.post('/login-webauthn-finish', async (req: Request, res: Re
 	console.log("webauthn login-finish", req.body);
 
 	const credential = req.body.credential;
-	const userHandle = credential.response.userHandle.toString();
+	const userId = UserId.fromUserHandle(credential.response.userHandle);
 	const credentialId = credential.rawId;
 
-	const userRes = await getUserByWebauthnCredential(userHandle, credentialId);
+	const userRes = await getUserByWebauthnCredential(userId, credentialId);
 	if (userRes.err) {
 		res.status(403).send({});
 		return;
@@ -335,12 +332,12 @@ userController.get('/account-info', async (req: Request, res: Response) => {
 	const keys = jsonParseTaggedBinary(user.keys.toString());
 
 	res.status(200).send({
+		uuid: user.uuid,
 		username: user.username,
 		displayName: user.displayName,
 		did: user.did,
 		hasPassword: user.passwordHash !== null,
 		publicKey: keys.publicKey,
-		webauthnUserHandle: user.webauthnUserHandle,
 		webauthnCredentials: (user.webauthnCredentials || []).map(cred => ({
 			createTime: cred.createTime,
 			credentialId: cred.credentialId,
@@ -353,12 +350,7 @@ userController.get('/account-info', async (req: Request, res: Response) => {
 })
 
 userController.post('/webauthn/register-begin', async (req: Request, res: Response) => {
-	const userRes = await updateUserByDID(req.user.did, (userEntity, manager) => {
-		if (!userEntity.webauthnUserHandle) {
-			userEntity.webauthnUserHandle = uuid.v4();
-		}
-		return userEntity;
-	});
+	const userRes = await getUserByDID(req.user.did);
 
 	if (userRes.err) {
 		res.status(403).send({});
@@ -367,7 +359,7 @@ userController.post('/webauthn/register-begin', async (req: Request, res: Respon
 	const user = userRes.unwrap();
 
 	const prfSalt = crypto.randomBytes(32);
-	const challengeRes = await createChallenge("create", user.webauthnUserHandle, prfSalt);
+	const challengeRes = await createChallenge("create", user.uuid, prfSalt);
 	if (challengeRes.err) {
 		res.status(500).send({});
 		return;
@@ -435,7 +427,7 @@ userController.post('/webauthn/register-finish', async (req: Request, res: Respo
 			userEntity.webauthnCredentials.push(
 				newWebauthnCredentialEntity({
 					credentialId: Buffer.from(verification.registrationInfo.credentialID),
-					userHandle: Buffer.from(userEntity.webauthnUserHandle),
+					_userHandle: user.uuid.asUserHandle(),
 					nickname: req.body.nickname,
 					publicKeyCose: Buffer.from(verification.registrationInfo.credentialPublicKey),
 					signatureCount: verification.registrationInfo.counter,

--- a/src/services/ClientKeystoreService.ts
+++ b/src/services/ClientKeystoreService.ts
@@ -3,11 +3,11 @@ import { inject, injectable } from "inversify";
 import "reflect-metadata";
 import { Err, Ok, Result } from "ts-results";
 
-import { AdditionalKeystoreParameters, RegistrationParams, SocketManagerServiceInterface, WalletKeystore, WalletKeystoreErr } from "./interfaces";
+import { AdditionalKeystoreParameters, SocketManagerServiceInterface, WalletKeystore, WalletKeystoreErr } from "./interfaces";
 import { TYPES } from "./types";
 import config from "../../config";
 import { SignatureAction, ServerSocketMessage } from "./shared.types";
-import { WalletKey } from "@wwwallet/ssi-sdk";
+import { UserId } from "../entities/user.entity";
 
 
 
@@ -23,7 +23,7 @@ export class ClientKeystoreService implements WalletKeystore {
 	) { }
 
 
-	async createIdToken(userDid: string, nonce: string, audience: string, additionalParameters: AdditionalKeystoreParameters): Promise<Result<{ id_token: string; }, WalletKeystoreErr>> {
+	async createIdToken(userId: UserId, nonce: string, audience: string, additionalParameters: AdditionalKeystoreParameters): Promise<Result<{ id_token: string; }, WalletKeystoreErr>> {
 		let message_id_sent = randomUUID();
 		const msg = {
 			message_id: message_id_sent,
@@ -33,9 +33,9 @@ export class ClientKeystoreService implements WalletKeystore {
 				audience: audience
 			}
 		}
-		await this.socketManagerService.send(userDid, msg as ServerSocketMessage)
+		await this.socketManagerService.send(userId, msg as ServerSocketMessage)
 
-		const result = await this.socketManagerService.expect(userDid, message_id_sent, SignatureAction.createIdToken);
+		const result = await this.socketManagerService.expect(userId, message_id_sent, SignatureAction.createIdToken);
 		if (result.err) {
 			return Err(WalletKeystoreErr.REMOTE_SIGNING_FAILED);
 		}
@@ -46,7 +46,7 @@ export class ClientKeystoreService implements WalletKeystore {
 		return Err(WalletKeystoreErr.REMOTE_SIGNING_FAILED);
 	}
 
-	async signJwtPresentation(userDid: string, nonce: string, audience: string, verifiableCredentials: any[], additionalParameters: AdditionalKeystoreParameters): Promise<Result<{ vpjwt: string }, WalletKeystoreErr>> {
+	async signJwtPresentation(userId: UserId, nonce: string, audience: string, verifiableCredentials: any[], additionalParameters: AdditionalKeystoreParameters): Promise<Result<{ vpjwt: string }, WalletKeystoreErr>> {
 		let message_id_sent = randomUUID();
 		const msg = {
 			message_id: message_id_sent,
@@ -57,9 +57,9 @@ export class ClientKeystoreService implements WalletKeystore {
 				verifiableCredentials: verifiableCredentials
 			}
 		}
-		await this.socketManagerService.send(userDid, msg as ServerSocketMessage)
+		await this.socketManagerService.send(userId, msg as ServerSocketMessage)
 
-		const result = await this.socketManagerService.expect(userDid, message_id_sent, SignatureAction.signJwtPresentation);
+		const result = await this.socketManagerService.expect(userId, message_id_sent, SignatureAction.signJwtPresentation);
 		if (result.err) {
 			return Err(WalletKeystoreErr.REMOTE_SIGNING_FAILED);
 		}
@@ -70,7 +70,7 @@ export class ClientKeystoreService implements WalletKeystore {
 		return Err(WalletKeystoreErr.REMOTE_SIGNING_FAILED);
 	}
 
-	async generateOpenid4vciProof(userDid: string, audience: string, nonce: string, additionalParameters: AdditionalKeystoreParameters): Promise<Result<{ proof_jwt: string }, WalletKeystoreErr>> {
+	async generateOpenid4vciProof(userId: UserId, audience: string, nonce: string, additionalParameters: AdditionalKeystoreParameters): Promise<Result<{ proof_jwt: string }, WalletKeystoreErr>> {
 		let message_id_sent = randomUUID();
 		const msg = {
 			message_id: message_id_sent,
@@ -81,8 +81,8 @@ export class ClientKeystoreService implements WalletKeystore {
 			}
 		}
 		console.log("MessageID = ", message_id_sent)
-		await this.socketManagerService.send(userDid, msg as ServerSocketMessage);
-		const result = await this.socketManagerService.expect(userDid, message_id_sent, SignatureAction.generateOpenid4vciProof);
+		await this.socketManagerService.send(userId, msg as ServerSocketMessage);
+		const result = await this.socketManagerService.expect(userId, message_id_sent, SignatureAction.generateOpenid4vciProof);
 		if (result.err) {
 			return Err(WalletKeystoreErr.REMOTE_SIGNING_FAILED);
 		}

--- a/src/services/DatabaseKeystoreService.ts
+++ b/src/services/DatabaseKeystoreService.ts
@@ -7,7 +7,7 @@ import { Err, Ok, Result } from "ts-results";
 import { SignVerifiablePresentationJWT, WalletKey } from "@wwwallet/ssi-sdk";
 import { AdditionalKeystoreParameters, DidKeyUtilityService, RegistrationParams, WalletKeystore, WalletKeystoreErr } from "./interfaces";
 import { verifiablePresentationSchemaURL } from "../util/util";
-import { getUserByDID } from "../entities/user.entity";
+import { getUser, UserId } from "../entities/user.entity";
 import { TYPES } from "./types";
 import config from "../../config";
 
@@ -33,8 +33,8 @@ export class DatabaseKeystoreService implements WalletKeystore {
 	}
 
 
-	async createIdToken(userDid: string, nonce: string, audience: string, additionalParameters: AdditionalKeystoreParameters): Promise<Result<{ id_token: string; }, WalletKeystoreErr>> {
-		const user = (await getUserByDID(userDid)).unwrap();
+	async createIdToken(userId: UserId, nonce: string, audience: string, additionalParameters: AdditionalKeystoreParameters): Promise<Result<{ id_token: string; }, WalletKeystoreErr>> {
+		const user = (await getUser(userId)).unwrap();
 		const keys = JSON.parse(user.keys.toString()) as WalletKey;
 
 		if (!keys.privateKey) {
@@ -58,8 +58,8 @@ export class DatabaseKeystoreService implements WalletKeystore {
 		return Ok({ id_token: jws });
 	}
 
-	async signJwtPresentation(userDid: string, nonce: string, audience: string, verifiableCredentials: any[], additionalParameters: AdditionalKeystoreParameters): Promise<Result<{ vpjwt: string }, WalletKeystoreErr>> {
-		const user = (await getUserByDID(userDid)).unwrap();
+	async signJwtPresentation(userId: UserId, nonce: string, audience: string, verifiableCredentials: any[], additionalParameters: AdditionalKeystoreParameters): Promise<Result<{ vpjwt: string }, WalletKeystoreErr>> {
+		const user = (await getUser(userId)).unwrap();
 		const keys = JSON.parse(user.keys.toString()) as WalletKey;
 		if (!keys.privateKey) {
 			return Err(WalletKeystoreErr.KEYS_UNAVAILABLE);
@@ -90,8 +90,8 @@ export class DatabaseKeystoreService implements WalletKeystore {
 		return Ok({ vpjwt: jws });
 	}
 
-	async generateOpenid4vciProof(userDid: string, audience: string, nonce: string, additionalParameters: AdditionalKeystoreParameters): Promise<Result<{ proof_jwt: string }, WalletKeystoreErr>> {
-		const user = (await getUserByDID(userDid)).unwrap();
+	async generateOpenid4vciProof(userId: UserId, audience: string, nonce: string, additionalParameters: AdditionalKeystoreParameters): Promise<Result<{ proof_jwt: string }, WalletKeystoreErr>> {
+		const user = (await getUser(userId)).unwrap();
 		const keys = JSON.parse(user.keys.toString()) as WalletKey;
 		if (!keys.privateKey) {
 			return Err(WalletKeystoreErr.KEYS_UNAVAILABLE);

--- a/src/services/interfaces.ts
+++ b/src/services/interfaces.ts
@@ -5,16 +5,16 @@ import { OutboundRequest } from "./types/OutboundRequest";
 import http from 'http';
 import { WalletKeystoreRequest, ServerSocketMessage, SignatureAction, ClientSocketMessage } from "./shared.types";
 import { WalletKey } from "@wwwallet/ssi-sdk";
-import { WalletType } from "../entities/user.entity";
+import { UserId, WalletType } from "../entities/user.entity";
 
 export interface OpenidCredentialReceiving {
 
-	generateAuthorizationRequestURL(userDid: string, credentialOfferURL?: string, legalPersonIdentifier?: string): Promise<{ redirect_to?: string, preauth?: boolean, ask_for_pin?: boolean }>;
+	generateAuthorizationRequestURL(userId: UserId, credentialOfferURL?: string, legalPersonIdentifier?: string): Promise<{ redirect_to?: string, preauth?: boolean, ask_for_pin?: boolean }>;
 
-	handleAuthorizationResponse(userDid: string, authorizationResponseURL: string): Promise<Result<void, IssuanceErr | WalletKeystoreRequest>>;
-	requestCredentialsWithPreAuthorizedGrant(userDid: string, user_pin: string): Promise<{error?: string}>;
+	handleAuthorizationResponse(userId: UserId, authorizationResponseURL: string): Promise<Result<void, IssuanceErr | WalletKeystoreRequest>>;
+	requestCredentialsWithPreAuthorizedGrant(userId: UserId, user_pin: string): Promise<{error?: string}>;
 
-	getIssuerState(userDid: string): Promise<{ issuer_state?: string, error?: Error }>
+	getIssuerState(userId: UserId): Promise<{ issuer_state?: string, error?: Error }>
 }
 
 export enum IssuanceErr {
@@ -43,18 +43,18 @@ export type RegistrationParams = {
 
 
 export interface WalletKeystoreManager {
-	initializeWallet(registrationParams: RegistrationParams): Promise<Result<{ fcmToken: string, keys: Buffer, did: string, displayName: string, privateData: Buffer, walletType: WalletType }, WalletKeystoreErr>>;
+	initializeWallet(registrationParams: RegistrationParams): Promise<Result<{ fcmToken: string, keys: Buffer, displayName: string, privateData: Buffer, walletType: WalletType }, WalletKeystoreErr>>;
 
-	createIdToken(userDid: string, nonce: string, audience: string, additionalParameters?: AdditionalKeystoreParameters): Promise<Result<{ id_token: string }, WalletKeystoreErr>>;
-	signJwtPresentation(userDid: string, nonce: string, audience: string, verifiableCredentials: any[], additionalParameters?: AdditionalKeystoreParameters): Promise<Result<{ vpjwt: string }, WalletKeystoreErr>>;
-	generateOpenid4vciProof(userDid: string, audience: string, nonce: string, additionalParameters?: AdditionalKeystoreParameters): Promise<Result<{ proof_jwt: string }, WalletKeystoreErr>>;
+	createIdToken(userId: UserId, nonce: string, audience: string, additionalParameters?: AdditionalKeystoreParameters): Promise<Result<{ id_token: string }, WalletKeystoreErr>>;
+	signJwtPresentation(userId: UserId, nonce: string, audience: string, verifiableCredentials: any[], additionalParameters?: AdditionalKeystoreParameters): Promise<Result<{ vpjwt: string }, WalletKeystoreErr>>;
+	generateOpenid4vciProof(userId: UserId, audience: string, nonce: string, additionalParameters?: AdditionalKeystoreParameters): Promise<Result<{ proof_jwt: string }, WalletKeystoreErr>>;
 }
 
 export interface WalletKeystore {
 
-	createIdToken(userDid: string, nonce: string, audience: string, additionalParameters?: AdditionalKeystoreParameters): Promise<Result<{ id_token: string }, WalletKeystoreErr>>;
-	signJwtPresentation(userDid: string, nonce: string, audience: string, verifiableCredentials: any[], additionalParameters?: AdditionalKeystoreParameters): Promise<Result<{ vpjwt: string }, WalletKeystoreErr>>;
-	generateOpenid4vciProof(userDid: string, audience: string, nonce: string, additionalParameters?: AdditionalKeystoreParameters): Promise<Result<{ proof_jwt: string }, WalletKeystoreErr>>;
+	createIdToken(userId: UserId, nonce: string, audience: string, additionalParameters?: AdditionalKeystoreParameters): Promise<Result<{ id_token: string }, WalletKeystoreErr>>;
+	signJwtPresentation(userId: UserId, nonce: string, audience: string, verifiableCredentials: any[], additionalParameters?: AdditionalKeystoreParameters): Promise<Result<{ vpjwt: string }, WalletKeystoreErr>>;
+	generateOpenid4vciProof(userId: UserId, audience: string, nonce: string, additionalParameters?: AdditionalKeystoreParameters): Promise<Result<{ proof_jwt: string }, WalletKeystoreErr>>;
 }
 
 export enum WalletKeystoreErr {
@@ -67,17 +67,9 @@ export enum WalletKeystoreErr {
 
 
 export interface OutboundCommunication {
-	initiateVerificationFlow(username: string, verifierId: number, scopeName: string): Promise<{ redirect_to?: string }>;
-
-	handleRequest(userDid: string, requestURL: string, camera_was_used: boolean): Promise<Result<OutboundRequest, WalletKeystoreRequest | HandleOutboundRequestError>>;
-
-	/**
-	 *
-	 * @param userDid
-	 * @param req
-	 * @param selection (key: descriptor_id, value: verifiable credential identifier)
-	 */
-	sendResponse(userDid: string, selection: Map<string, string>): Promise<Result<{ redirect_to?: string }, WalletKeystoreRequest | SendResponseError>>;
+	initiateVerificationFlow(userId: UserId, verifierId: number, scopeName: string): Promise<{ redirect_to?: string }>;
+	handleRequest(userId: UserId, requestURL: string, camera_was_used: boolean): Promise<Result<OutboundRequest, WalletKeystoreRequest | HandleOutboundRequestError>>;
+	sendResponse(userId: UserId, selection: Map<string, string>): Promise<Result<{ redirect_to?: string }, WalletKeystoreRequest | SendResponseError>>;
 }
 
 
@@ -102,6 +94,6 @@ export enum ExpectingSocketMessageErr {
 export interface SocketManagerServiceInterface {
 	register(server: http.Server);
 
-	send(userDid: string, message: ServerSocketMessage): Promise<Result<void, void>>;
-	expect(userDid: string, message_id: string, action: SignatureAction): Promise<Result<{ message: ClientSocketMessage }, ExpectingSocketMessageErr>>;
+	send(userId: UserId, message: ServerSocketMessage): Promise<Result<void, void>>;
+	expect(userId: UserId, message_id: string, action: SignatureAction): Promise<Result<{ message: ClientSocketMessage }, ExpectingSocketMessageErr>>;
 }

--- a/src/webauthn.ts
+++ b/src/webauthn.ts
@@ -1,5 +1,5 @@
 import config from '../config';
-import { WebauthnCredentialEntity } from './entities/user.entity';
+import { UserId, WebauthnCredentialEntity } from './entities/user.entity';
 
 
 export function getRpId(): string {
@@ -14,7 +14,7 @@ export function makeCreateOptions({
 	challenge: Buffer,
 	prfSalt?: Buffer,
 	user: {
-		webauthnUserHandle: string,
+		uuid: UserId,
 		name: string,
 		displayName: string,
 		webauthnCredentials?: WebauthnCredentialEntity[],
@@ -24,7 +24,7 @@ export function makeCreateOptions({
 		publicKey: {
 			rp: config.webauthn.rp,
 			user: {
-				id: Buffer.from(user.webauthnUserHandle, "utf8"),
+				id: user.uuid.asUserHandle(),
 				name: user.name,
 				displayName: user.displayName,
 			},


### PR DESCRIPTION
Currently, we use the DID of the user account's public key as a canonical identifier for the account. For "phase 1" of https://github.com/wwWallet/wallet-ecosystem/issues/62, user accounts will no longer have only a single key pair per account, but multiple key pairs, so there will no longer be a canonical key whose DID to use. Instead, we can take the UUID that we currently use only as the WebAuthn user handle and use that as a canonical identifier for the account.

This only changes the application layer - the database schema remains unchanged, so this should be forward- and backwards compatible with earlier versions of the app.

This depends on:

- https://github.com/wwWallet/wallet-backend-server/pull/63
- https://github.com/wwWallet/wallet-backend-server/pull/64

This is mutually dependent on:
- https://github.com/wwWallet/wallet-frontend/pull/303