### PR TITLE
Support unique, per-credential key pairs

### DIFF
--- a/src/routers/user.router.ts
+++ b/src/routers/user.router.ts
@@ -326,14 +326,11 @@ userController.get('/account-info', async (req: Request, res: Response) => {
 	}
 	const user = userRes.unwrap();
 
-	const keys = jsonParseTaggedBinary(user.keys.toString());
-
 	res.status(200).send({
 		uuid: user.uuid,
 		username: user.username,
 		displayName: user.displayName,
 		hasPassword: user.passwordHash !== null,
-		publicKey: keys.publicKey,
 		webauthnCredentials: (user.webauthnCredentials || []).map(cred => ({
 			createTime: cred.createTime,
 			credentialId: cred.credentialId,

--- a/src/services/WalletKeystoreManagerService.ts
+++ b/src/services/WalletKeystoreManagerService.ts
@@ -21,10 +21,10 @@ export class WalletKeystoreManagerService implements WalletKeystoreManager {
 		const fcmToken = registrationParams.fcm_token ? registrationParams.fcm_token : "";
 
 		// depending on additionalParameters, decide to use the corresponding keystore service
-		if (registrationParams.keys && registrationParams.privateData) {
+		if (registrationParams.privateData) {
 			return Ok({
 				fcmToken,
-				keys: Buffer.from(JSON.stringify(registrationParams.keys)),
+				keys: Buffer.from(""),
 				displayName: registrationParams.displayName,
 				privateData: Buffer.from(registrationParams.privateData),
 				walletType: WalletType.CLIENT


### PR DESCRIPTION
Companion PR of:
- https://github.com/wwWallet/wallet-frontend/pull/307

This is "phase 1" of https://github.com/wwWallet/wallet-ecosystem/issues/62. Most of this happens in the frontend where we have the keys decrypted; the backend just needs to no longer assume that a key pair will be provided during registration.

This depends on:

- https://github.com/wwWallet/wallet-backend-server/pull/63
- https://github.com/wwWallet/wallet-backend-server/pull/64
- https://github.com/wwWallet/wallet-backend-server/pull/65
