### PR TITLE
Optimize Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,19 +4,15 @@ WORKDIR /app
 
 COPY . .
 COPY ./config/config.template.ts ./config/index.ts
-RUN apt-get update -y && apt-get install g++ python3 make -y && yarn cache clean && yarn install && yarn build
+RUN apt-get update -y && apt-get install g++ python3 make -y
+RUN yarn cache clean && yarn install --production && yarn build
 
 # Production stage
 FROM node:18-bullseye-slim AS production
 WORKDIR /app
 
-COPY --from=builder /app/package.json .
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/public ./public
-
-
-
-RUN apt-get update -y && apt-get install g++ python3 make -y && yarn install --production
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
It seemed a little redundant that the package.json file was copied in the deploy step and yarn install was executed in both steps. Builds will be faster if `yarn install --production` is executed only in the build step.