### PR TITLE
Fix comment syntax in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,7 @@ trim_trailing_whitespace = true
 [{*.{Dockerfile,css,js,jsx,ts,tsx},Dockerfile}]
 indent_style = tab
 
-[*.{yml,yaml}] # YAML does not allow tab indentation
+# YAML does not allow tab indentation
+[*.{yml,yaml}]
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
Without this change, my Emacs editorconfig integration fails to read the file with the following error:

```
⛔ Warning (editorconfig): Failed to get properties, styles will not be applied: (editorconfig-error "Error from editorconfig-get-properties-function: (error \"Error while reading config file: <redacted>/wallet-ecosystem/wallet-backend-server/.editorconfig:11:
    [*.{yml,yaml}] # YAML does not allow tab indentation
\")")
```

`editorconfig-checker` doesn't seem to have a problem with it, so maybe it's specific to the Emacs integration. Anyway, moving the comment doesn't hurt.