### PR TITLE
Schema extensions to support batch issuance

### DIFF
--- a/src/entities/VerifiableCredential.entity.ts
+++ b/src/entities/VerifiableCredential.entity.ts
@@ -28,6 +28,12 @@ export class VerifiableCredentialEntity {
 
 	@Column({ type: "varchar", nullable: false, default: "" })
 	credentialIssuerIdentifier: string = "";
+
+	@Column({ type: "smallint", nullable: false, default: 0 })
+	instanceId: number = 0;
+
+	@Column({ type: "smallint", nullable: false, default: 0 })
+	sigCount: number = 0;
 }
 
 
@@ -59,6 +65,24 @@ async function createVerifiableCredential(createVc: Partial<VerifiableCredential
 			.into(VerifiableCredentialEntity).values([
 				{...vc }
 			])
+			.execute();
+		return Ok({});
+	}
+	catch(e) {
+		console.log(e);
+		return Err(CreateVerifiableCredentialErr.DB_ERR);
+	}
+}
+
+
+async function updateVerifiableCredential(credential: Partial<VerifiableCredentialEntity>) {
+	try {
+		console.log("Updating VC...")
+		await AppDataSource
+			.createQueryBuilder()
+			.update(VerifiableCredentialEntity)
+			.set({ ...credential })
+			.where("credentialIdentifier = :cred_id and instanceId = :instance_id", { cred_id: credential.credentialIdentifier, instance_id: credential.instanceId })
 			.execute();
 		return Ok({});
 	}
@@ -162,6 +186,7 @@ export {
 	DeleteVerifiableCredentialErr,
 	getAllVerifiableCredentials,
 	createVerifiableCredential,
+	updateVerifiableCredential,
 	deleteVerifiableCredential,
 	getVerifiableCredentialByCredentialIdentifier,
 	deleteAllCredentialsWithHolderDID

--- a/src/routers/storage.router.ts
+++ b/src/routers/storage.router.ts
@@ -1,5 +1,5 @@
 import express, { Request, Response, Router } from "express";
-import { getAllVerifiableCredentials, getVerifiableCredentialByCredentialIdentifier, deleteVerifiableCredential, createVerifiableCredential } from "../entities/VerifiableCredential.entity";
+import { getAllVerifiableCredentials, getVerifiableCredentialByCredentialIdentifier, deleteVerifiableCredential, createVerifiableCredential, updateVerifiableCredential, VerifiableCredentialEntity } from "../entities/VerifiableCredential.entity";
 import { createVerifiablePresentation, deletePresentationsByCredentialId, getAllVerifiablePresentations, getPresentationByIdentifier } from "../entities/VerifiablePresentation.entity";
 import { sendPushNotification } from "../lib/firebase";
 import { getUser } from "../entities/user.entity";
@@ -7,7 +7,9 @@ import { getUser } from "../entities/user.entity";
 
 const storageRouter: Router = express.Router();
 
-storageRouter.post('/vc', storeCredential);
+storageRouter.post('/vc', storeCredentials);
+storageRouter.post('/vc/update', updateCredential);
+
 storageRouter.get('/vc', getAllVerifiableCredentialsController);
 storageRouter.get('/vc/:credential_identifier', getVerifiableCredentialByCredentialIdentifierController);
 storageRouter.delete('/vc/:credential_identifier', deleteVerifiableCredentialController);
@@ -16,20 +18,23 @@ storageRouter.get('/vp', getAllVerifiablePresentationsController);
 storageRouter.get('/vp/:presentation_identifier', getPresentationByPresentationIdentifierController);
 
 
-async function storeCredential(req: Request, res: Response) {
-	createVerifiableCredential({
-		holderDID: req.user.did,
-		issuanceDate: new Date(),
-		...req.body,
-	}).then(async () => {
-		// inform all installed instances of the wallet that a credential has been received
+async function storeCredentials(req: Request, res: Response) {
+	const u = await getUser(req.user.id);
+	if (u.err) {
+		return res.status(400).send({ error: "Unauthenticated user" });
+	}
+	const user = u.unwrap();
 
-		const u = await getUser(req.user.id);
-		if (u.err) {
-			return res.send({});
-		}
-
-		const user = u.unwrap();
+	if (!req.body.credentials || !(req.body.credentials instanceof Array)) {
+		return res.status(400).send({ error: "Missing or invalid 'credentials' body param" });
+	}
+	Promise.all(req.body.credentials.map(async (storableCredential) => {
+		createVerifiableCredential({
+			holderDID: req.user.did,
+			issuanceDate: new Date(),
+			...storableCredential,
+		});
+	})).then(() => {
 		if (user.fcmTokenList) {
 			for (const fcmToken of user.fcmTokenList) {
 				sendPushNotification(fcmToken.value, "New Credential", "A new verifiable credential is in your wallet").catch(err => {
@@ -38,8 +43,27 @@ async function storeCredential(req: Request, res: Response) {
 				});
 			}
 		}
-	})
+	});
 	res.send({});
+}
+
+async function updateCredential(req: Request, res: Response) {
+	try {
+		const u = await getUser(req.user.id);
+		if (u.err) {
+			return res.status(400).send({ error: "Unauthenticated user" });
+		}
+		const user = u.unwrap();
+		if (!req.body.credential) {
+			return res.status(400).send({ error: "Missing or invalid 'credential' body param" });
+		}
+		await updateVerifiableCredential(req.body.credential);	
+		return res.status(200).send({});
+	}
+	catch(err) {
+		console.error(err);
+		return res.status(400).send({ error: JSON.stringify(err) });
+	}
 }
 
 async function getAllVerifiableCredentialsController(req: Request, res: Response) {

--- a/src/routers/storage.router.ts
+++ b/src/routers/storage.router.ts
@@ -57,10 +57,10 @@ async function updateCredential(req: Request, res: Response) {
 		if (!req.body.credential) {
 			return res.status(400).send({ error: "Missing or invalid 'credential' body param" });
 		}
-		await updateVerifiableCredential(req.body.credential);	
+		await updateVerifiableCredential(req.body.credential);
 		return res.status(200).send({});
 	}
-	catch(err) {
+	catch (err) {
 		console.error(err);
 		return res.status(400).send({ error: JSON.stringify(err) });
 	}


### PR DESCRIPTION
Introduction of sigCount and instanceId db attributes on the VerifiableCredentialEntity

- `instanceId` is the serial number of the credential of the same batch. To ensure backwards-compatibility, this number is 0 by-default and the first instance always has 0 value as instanceId.

- `sigCount` maintains the number of the presentations that this credential was used for.