### PR TITLE
Changed UserEntity.privateData column datatype from blob to mediumblob

### DIFF
--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -107,7 +107,7 @@ class UserEntity {
 	@Column({ type: "bool", default: false })
 	isAdmin: boolean = false;
 
-	@Column({ type: "blob", nullable: false })
+	@Column({ type: "mediumblob", nullable: false })
 	privateData: Buffer;
 
 


### PR DESCRIPTION
For the time being, changing the datatype from `blob` to `mediumblob` will avoid running out of the privateData column limits. Other datatypes or/with compression can be added in a different PR.

See related discussion on issue https://github.com/wwWallet/wallet-frontend/issues/409