### PR TITLE
Set limit of accepted payloads

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -22,8 +22,8 @@ const app: Express = express();
 // __dirname is "/path/to/dist/src"
 
 app.use(cookieParser());
-app.use(bodyParser.urlencoded({ extended: true }));
-app.use(bodyParser.json({ reviver: reviverTaggedBase64UrlToBuffer }));
+app.use(bodyParser.urlencoded({ extended: true, limit: '17mb' }));
+app.use(bodyParser.json({ reviver: reviverTaggedBase64UrlToBuffer, limit: '17mb' }));
 app.set('json replacer', replacerBufferToTaggedBase64Url);
 
 app.use(express.static('public'));


### PR DESCRIPTION
This change covers the case where the default limit of the `body-parser` is exceeded. Since the privateData cannot exceed 16mb, an additional 1mb has been added to the limit.