### PR TITLE
Send data-only payloads via FCM to prevent duplicate background notifications

### DIFF
--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -26,11 +26,9 @@ if (config.notifications.enabled) {
 const sendPushNotification = async (fcm_token, title, body) => {
 	try {
 		let message = {
-			notification: {
+			data: {
 				title,
 				body,
-			},
-			data: {
 				scope: '/firebase-cloud-messaging-push-scope'
 			},
 			apns: {


### PR DESCRIPTION
Removes notification payload from FCM messages to avoid duplicate display.
The service worker will handle notification rendering exclusively.