### PR TITLE
Minimize docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 COPY . .
 COPY ./config/config.template.ts ./config/index.ts
-RUN apt-get update -y && apt-get install g++ python3 make -y && yarn cache clean && yarn install && yarn build
+RUN apt-get update -y && apt-get install g++ python3 make -y && yarn cache clean && yarn install && yarn build && rm -rf node_modules/ && yarn install --production
 
 # Production stage
 FROM node:18-bullseye-slim AS production
@@ -12,11 +12,8 @@ WORKDIR /app
 
 COPY --from=builder /app/package.json .
 COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/public ./public
-
-
-
-RUN apt-get update -y && apt-get install g++ python3 make -y && yarn install --production
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
This PR avoids re-installing the dependencies on the production stage. Results in smaller image size.