### PR TITLE
Recognize If-None-Match header in GET /session/private-data

### DIFF
--- a/src/routers/user.router.ts
+++ b/src/routers/user.router.ts
@@ -592,23 +592,6 @@ userController.get('/private-data', async (req: Request, res: Response) => {
 	}
 });
 
-userController.get('/private-data/etag', async (req: Request, res: Response) => {
-	const userRes = await getUser(req.user.id);
-	if (userRes.ok) {
-		const privateData = userRes.val.privateData;
-		res.status(200)
-			.header({ 'X-Private-Data-ETag': privateDataEtag(privateData) })
-			.send({ });
-	} else {
-		if (userRes.val === GetUserErr.NOT_EXISTS) {
-			res.status(404).send();
-
-		} else {
-			res.status(500).send();
-		}
-	}
-});
-
 userController.delete('/', async (req: Request, res: Response) => {
 	try {
 		await runTransaction(async (entityManager: EntityManager) => {

--- a/src/routers/user.router.ts
+++ b/src/routers/user.router.ts
@@ -579,9 +579,13 @@ userController.get('/private-data', async (req: Request, res: Response) => {
 	const userRes = await getUser(req.user.id);
 	if (userRes.ok) {
 		const privateData = userRes.val.privateData;
-		res.status(200)
-			.header({ 'X-Private-Data-ETag': privateDataEtag(privateData) })
-			.send({ privateData });
+		const etag = privateDataEtag(privateData);
+		const header = { 'X-Private-Data-ETag': etag };
+		if (req.headers['if-none-match'] === etag || req.headers['x-private-data-if-none-match'] === etag) {
+			res.status(304).header(header).send();
+		} else {
+			res.status(200).header(header).send({ privateData });
+		}
 	} else {
 		if (userRes.val === GetUserErr.NOT_EXISTS) {
 			res.status(404).send();


### PR DESCRIPTION
Alternative to #98.

If `GET /session/private-data` is called with an [`If-None-Match`][1] or `X-Private-Data-If-None-Match` header, then the request is a [conditional request][2] and will return [304 Not Modified][3] if the header value matches the ETag value that would be returned in a 200 OK response. This enables clients to atomically update their local copy of the private data only if needed, while not re-sending another copy of the same private data when not needed.

[1]: https://www.rfc-editor.org/rfc/rfc9110.html#name-if-none-match
[2]: https://www.rfc-editor.org/rfc/rfc9110.html#name-conditional-requests
[3]: https://www.rfc-editor.org/rfc/rfc9110.html#name-304-not-modified
