### PR TITLE
fix: allow tenant id header

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -32,7 +32,7 @@ app.use(express.static('public'));
 app.use(cors({
 	credentials: true,
 	origin: true,
-	allowedHeaders: ['Authorization', 'Content-Type', 'If-None-Match', 'X-Private-Data-If-Match', 'X-Private-Data-If-None-Match'],
+	allowedHeaders: ['Authorization', 'Content-Type', 'If-None-Match', 'X-Private-Data-If-Match', 'X-Private-Data-If-None-Match', 'X-Tenant-ID'],
 	exposedHeaders: ['X-Private-Data-ETag'],
 }));
 


### PR DESCRIPTION
In the new multi-tenancy PR, the frontend sends a new header `X-Tenant-ID` to the backend to indicate which tenant is being accessed. 
For backwards compatibility, this backend should allow the header, even if it doesn't use it.

Reference: https://github.com/wwWallet/wallet-frontend/pull/993
