### PR TITLE
Add dev proxy configuration

### DIFF
--- a/config/config.template.ts
+++ b/config/config.template.ts
@@ -24,5 +24,7 @@ export const config = {
 	},
 	alg: process.env.ALG || "EdDSA",
 	keysDir: process.env.KEYS_DIR || undefined,
-	ohttpGatewayUrl: process.env.OHTTP_GATEWAY_URL || "http://localhost:4567"
+	ohttpGatewayUrl: process.env.OHTTP_GATEWAY_URL || "http://localhost:4567",
+	debugAcceptUnauthorizedHttps: (process.env.DEBUG_ACCEPT_UNAUTHORIZED_HTTPS &&
+		process.env.DEBUG_ACCEPT_UNAUTHORIZED_HTTPS.toLowerCase() === "true") ?? false
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -58,7 +58,6 @@ if (process.env.NODE_ENV === "production") {
 	const enabledUnsafeEnvironmentVariables = getEnabledUnsafeEnvironmentVariables();
 	if (enabledUnsafeEnvironmentVariables.length > 0) {
 		const names = enabledUnsafeEnvironmentVariables
-			.map(([key]) => key)
 			.join(', ');
 
 		console.error(

--- a/src/app.ts
+++ b/src/app.ts
@@ -17,6 +17,7 @@ import { helperRouter } from './routers/helper.router';
 import { verifierRouter } from './routers/verifier.router';
 import { walletProviderRouter } from './routers/wallet_provider.router';
 import { ohttpRelayRouter } from './routers/ohttp_relay.router';
+import { getEnabledUnsafeEnvironmentVariables } from './configValidation';
 
 
 const app: Express = express();
@@ -52,6 +53,21 @@ app.use('/helper', helperRouter);
 app.use('/relay', ohttpRelayRouter);
 app.use('/verifier', verifierRouter);
 app.use('/wallet-provider', walletProviderRouter);
+
+if (process.env.NODE_ENV === "production") {
+	const enabledUnsafeEnvironmentVariables = getEnabledUnsafeEnvironmentVariables();
+	if (enabledUnsafeEnvironmentVariables.length > 0) {
+		const names = enabledUnsafeEnvironmentVariables
+			.map(([key]) => key)
+			.join(', ');
+
+		console.error(
+			`FATAL: Unsafe env flags enabled in production: ${names}`
+		);
+
+		process.exit(1);
+	}
+}
 
 const server = http.createServer(app);
 appContainer.get<SocketManagerServiceInterface>(TYPES.SocketManagerService).register(server);

--- a/src/app.ts
+++ b/src/app.ts
@@ -17,7 +17,7 @@ import { helperRouter } from './routers/helper.router';
 import { verifierRouter } from './routers/verifier.router';
 import { walletProviderRouter } from './routers/wallet_provider.router';
 import { ohttpRelayRouter } from './routers/ohttp_relay.router';
-import { getEnabledUnsafeEnvironmentVariables } from './configValidation';
+import { getUnsafeEnvironmentVariables } from './configValidation';
 
 
 const app: Express = express();
@@ -55,13 +55,13 @@ app.use('/verifier', verifierRouter);
 app.use('/wallet-provider', walletProviderRouter);
 
 if (process.env.NODE_ENV === "production") {
-	const enabledUnsafeEnvironmentVariables = getEnabledUnsafeEnvironmentVariables();
-	if (enabledUnsafeEnvironmentVariables.length > 0) {
-		const names = enabledUnsafeEnvironmentVariables
+	const unsafeEnvironmentVariables = getUnsafeEnvironmentVariables();
+	if (unsafeEnvironmentVariables.length > 0) {
+		const names = unsafeEnvironmentVariables
 			.join(', ');
 
 		console.error(
-			`FATAL: Unsafe env flags enabled in production: ${names}`
+			`FATAL: Unsafe env flags found in production: ${names}`
 		);
 
 		process.exit(1);

--- a/src/configValidation.ts
+++ b/src/configValidation.ts
@@ -1,0 +1,29 @@
+const truthyEnvValues = new Set([
+	'true',
+	'1',
+	'yes',
+	'on',
+]);
+
+const unsafeEnvPrefixes = [
+	'DEBUG_',
+	'DEV_',
+	'UNSAFE_',
+	'INSECURE_',
+];
+
+const isTruthy = (value?: string): boolean =>
+	truthyEnvValues.has(
+		value?.trim().toLowerCase() ?? ''
+	);
+
+export function getEnabledUnsafeEnvironmentVariables(): string[] {
+	return Object.entries(process.env)
+		.filter(([key]) =>
+			unsafeEnvPrefixes.some(prefix =>
+				key.startsWith(prefix)
+			)
+		)
+		.filter(([, value]) => isTruthy(value))
+		.map(([key]) => key);
+}

--- a/src/configValidation.ts
+++ b/src/configValidation.ts
@@ -1,10 +1,3 @@
-const truthyEnvValues = new Set([
-	'true',
-	'1',
-	'yes',
-	'on',
-]);
-
 const unsafeEnvPrefixes = [
 	'DEBUG_',
 	'DEV_',
@@ -12,18 +5,12 @@ const unsafeEnvPrefixes = [
 	'INSECURE_',
 ];
 
-const isTruthy = (value?: string): boolean =>
-	truthyEnvValues.has(
-		value?.trim().toLowerCase() ?? ''
-	);
-
-export function getEnabledUnsafeEnvironmentVariables(): string[] {
+export function getUnsafeEnvironmentVariables(): string[] {
 	return Object.entries(process.env)
 		.filter(([key]) =>
 			unsafeEnvPrefixes.some(prefix =>
 				key.startsWith(prefix)
 			)
 		)
-		.filter(([, value]) => isTruthy(value))
 		.map(([key]) => key);
 }

--- a/src/routers/helper.router.ts
+++ b/src/routers/helper.router.ts
@@ -2,12 +2,12 @@ import axios from "axios";
 import { Router } from "express";
 import https from 'https';
 import { getAllTrustedRootCertificates } from "../entities/TrustedRootCertificate.entity";
-
+import { config } from "../../config";
 
 const helperRouter = Router()
 
 const agent = new https.Agent({
-	// rejectUnauthorized: false, // Accept self-signed certificates for testing purposes
+	rejectUnauthorized: !config.debugAcceptUnauthorizedHttps
 });
 
 helperRouter.all('/auth-check', (req, res) => {

--- a/src/routers/proxy.router.ts
+++ b/src/routers/proxy.router.ts
@@ -1,10 +1,12 @@
 import axios from 'axios';
 import express, { Router } from 'express';
 import https from 'https';
+import { config } from '../../config';
+
 const proxyRouter: Router = express.Router();
 
 const agent = new https.Agent({
-	// rejectUnauthorized: false, // Accept self-signed certificates for testing purposes
+	rejectUnauthorized: !config.debugAcceptUnauthorizedHttps
 });
 
 proxyRouter.post('/', async (req, res) => {

--- a/src/routers/proxy.router.ts
+++ b/src/routers/proxy.router.ts
@@ -1,6 +1,11 @@
 import axios from 'axios';
-import express, { Request, Response, Router } from 'express';
+import express, { Router } from 'express';
+import https from 'https';
 const proxyRouter: Router = express.Router();
+
+const agent = new https.Agent({
+	// rejectUnauthorized: false, // Accept self-signed certificates for testing purposes
+});
 
 proxyRouter.post('/', async (req, res) => {
 	const { headers, method, url, data } = req.body;
@@ -10,6 +15,7 @@ proxyRouter.post('/', async (req, res) => {
 		const response = await axios({
 			url: url,
 			headers: headers,
+			httpsAgent: agent,
 			method: method,
 			data: data,
 			...(isBinaryRequest && { responseType: 'arraybuffer' }),


### PR DESCRIPTION
This PR adds the option to configure a dev proxy that does not reject unauthorized HTTPS connections, to aid with local development.

A safeguard has been added to avoid deploying with this flag or other unsafe development flags when using NODE_ENV = production.