### PR TITLE
Display WebAuthn Credential Sync Status

### DIFF
--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -168,6 +168,12 @@ class WebauthnCredentialEntity {
 	@Column({ nullable: false })
 	prfCapable: boolean;
 
+	@Column({ nullable: false })
+	backupEligibility: boolean;
+
+	@Column({ nullable: false })
+	backupState: boolean;
+
 	getCredentialDescriptor() {
 		return {
 			type: "public-key",

--- a/src/migrations/1782737022760-AddSyncableToWebauthnCredential.ts
+++ b/src/migrations/1782737022760-AddSyncableToWebauthnCredential.ts
@@ -1,15 +1,14 @@
 import { MigrationInterface, QueryRunner } from "typeorm";
 
 export class AddSyncableToWebauthnCredential1782737022760 implements MigrationInterface {
-  name = 'AddSyncableToWebauthnCredential1782737022760'
 
-  public async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`ALTER TABLE \`webauthn_credential\` ADD \`backupEligibility\` BOOLEAN NOT NULL DEFAULT 0`);
-    await queryRunner.query(`ALTER TABLE \`webauthn_credential\` ADD \`backupState\` BOOLEAN NOT NULL DEFAULT 0`);
-  }
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(`ALTER TABLE \`webauthn_credential\` ADD \`backupEligibility\` BOOLEAN NOT NULL DEFAULT 0`);
+		await queryRunner.query(`ALTER TABLE \`webauthn_credential\` ADD \`backupState\` BOOLEAN NOT NULL DEFAULT 0`);
+	}
 
-  public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`ALTER TABLE \`webauthn_credential\` DROP COLUMN \`backupEligibility\``);
-    await queryRunner.query(`ALTER TABLE \`webauthn_credential\` DROP COLUMN \`backupState\``);
-  }
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(`ALTER TABLE \`webauthn_credential\` DROP COLUMN \`backupEligibility\``);
+		await queryRunner.query(`ALTER TABLE \`webauthn_credential\` DROP COLUMN \`backupState\``);
+	}
 }

--- a/src/migrations/1782737022760-AddSyncableToWebauthnCredential.ts
+++ b/src/migrations/1782737022760-AddSyncableToWebauthnCredential.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddSyncableToWebauthnCredential1782737022760 implements MigrationInterface {
+  name = 'AddSyncableToWebauthnCredential1782737022760'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE \`webauthn_credential\` ADD \`backupEligibility\` BOOLEAN NOT NULL DEFAULT 0`);
+    await queryRunner.query(`ALTER TABLE \`webauthn_credential\` ADD \`backupState\` BOOLEAN NOT NULL DEFAULT 0`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE \`webauthn_credential\` DROP COLUMN \`backupEligibility\``);
+    await queryRunner.query(`ALTER TABLE \`webauthn_credential\` DROP COLUMN \`backupState\``);
+  }
+}

--- a/src/routers/user.router.ts
+++ b/src/routers/user.router.ts
@@ -186,6 +186,7 @@ noAuthUserController.post('/register-webauthn-finish', async (req: Request, res:
 		if (walletInitializationResult.err) {
 			return res.status(400).send({ error: walletInitializationResult.val })
 		}
+		var flags = webauthn.parseAuthenticatorFlags(credential.response.attestationObject,true);
 
 		const newUser: CreateUser = {
 			...walletInitializationResult.unwrap(),
@@ -201,6 +202,8 @@ noAuthUserController.post('/register-webauthn-finish', async (req: Request, res:
 					attestationObject: credential.response.attestationObject,
 					create_clientDataJSON: credential.response.clientDataJSON,
 					prfCapable: credential.clientExtensionResults?.prf?.enabled || false,
+					backupEligibility: flags.backupEligibility,
+					backupState: flags.backupState
 				}),
 			],
 		};
@@ -291,9 +294,12 @@ noAuthUserController.post('/login-webauthn-finish', async (req: Request, res: Re
 	}
 
 	if (verification.verified) {
+		var flags = webauthn.parseAuthenticatorFlags(credential.response.authenticatorData,false);
 		const updateCredentialRes = await updateWebauthnCredential(credentialRecord, (entity) => {
 			entity.signatureCount = verification.authenticationInfo.newCounter;
 			entity.lastUseTime = new Date();
+			entity.backupEligibility = flags.backupEligibility;
+			entity.backupState = flags.backupState;
 			return entity;
 		});
 
@@ -334,6 +340,8 @@ userController.get('/account-info', async (req: Request, res: Response) => {
 			lastUseTime: cred.lastUseTime,
 			nickname: cred.nickname,
 			prfCapable: cred.prfCapable,
+			backupEligibility: cred.backupEligibility,
+			backupState: cred.backupState,
 		})),
 	});
 })
@@ -424,6 +432,7 @@ userController.post('/webauthn/register-finish', async (req: Request, res: Respo
 	}
 
 	if (verification.verified) {
+		var flags = webauthn.parseAuthenticatorFlags(credential.response.attestationObject,true);
 		const updateUserRes = await updateUser(user.uuid, (userEntity, manager) => {
 			userEntity.webauthnCredentials = userEntity.webauthnCredentials || [];
 			userEntity.webauthnCredentials.push(
@@ -437,6 +446,8 @@ userController.post('/webauthn/register-finish', async (req: Request, res: Respo
 					attestationObject: Buffer.from(verification.registrationInfo.attestationObject),
 					create_clientDataJSON: Buffer.from(credential.response.clientDataJSON),
 					prfCapable: credential.clientExtensionResults?.prf?.enabled || false,
+					backupEligibility: flags.backupEligibility,
+					backupState: flags.backupState
 				}, manager)
 			);
 

--- a/src/webauthn.ts
+++ b/src/webauthn.ts
@@ -110,7 +110,15 @@ function parseAuthenticatorFlagsFromAuthenticatorData(authenticatorData: Buffer 
 	const data = toUint8Array(authenticatorData);
 
 	if (data.length < 37) {
-		throw new Error("Invalid authenticatorData: too short");
+		return {
+			userPresent: false,
+			userVerified: false,
+			backupEligibility: false,
+			backupState: false,
+			attestedCredentialData: false,
+			extensionData: false,
+			rawFlagsByte: 0,
+		};
 	}
 
 	const flags = data[32];
@@ -118,7 +126,7 @@ function parseAuthenticatorFlagsFromAuthenticatorData(authenticatorData: Buffer 
 	return {
 		userPresent: Boolean(flags & 0x01),             // bit 0 - UP
 		userVerified: Boolean(flags & 0x04),            // bit 2 - UV
-		backupEligibility: Boolean(flags & 0x08),          // bit 3 - BE
+		backupEligibility: Boolean(flags & 0x08),       // bit 3 - BE
 		backupState: Boolean(flags & 0x10),             // bit 4 - BS
 		attestedCredentialData: Boolean(flags & 0x40),  // bit 6 - AT
 		extensionData: Boolean(flags & 0x80),           // bit 7 - ED
@@ -131,7 +139,15 @@ export function parseAuthenticatorFlags(input: Buffer | Uint8Array,isAttestation
 		const decoded = cbor.decode(input);
 
 		if (!decoded.authData) {
-			throw new Error("Invalid attestationObject: missing authData");
+			return {
+				userPresent: false,
+				userVerified: false,
+				backupEligibility: false,
+				backupState: false,
+				attestedCredentialData: false,
+				extensionData: false,
+				rawFlagsByte: 0,
+			};
 		}
 
 		return parseAuthenticatorFlagsFromAuthenticatorData(decoded.authData);

--- a/src/webauthn.ts
+++ b/src/webauthn.ts
@@ -88,3 +88,60 @@ export function stripAttestationStatement(attObj: Buffer | Uint8Array): Buffer {
 	});
 	return enc;
 }
+
+type AuthenticatorFlags = {
+	userPresent: boolean;              // UP
+  	userVerified: boolean;             // UV
+  	backupEligibility: boolean;        // BE
+  	backupState: boolean;              // BS
+  	attestedCredentialData: boolean;   // AT
+  	extensionData: boolean;            // ED
+  	rawFlagsByte: number;
+};
+
+function toUint8Array(value: Buffer | Uint8Array | ArrayBuffer): Uint8Array {
+  	if (value instanceof Uint8Array) {
+    	return value;
+  	}
+
+  	return new Uint8Array(value);
+}
+
+function parseAuthenticatorFlagsFromAuthenticatorData(
+  	authenticatorData: Buffer | Uint8Array | ArrayBuffer
+): AuthenticatorFlags {
+  	const data = toUint8Array(authenticatorData);
+
+  	if (data.length < 37) {
+    	throw new Error("Invalid authenticatorData: too short");
+  	}
+
+  	const flags = data[32];
+
+  	return {
+    	userPresent: Boolean(flags & 0x01),             // bit 0 - UP
+    	userVerified: Boolean(flags & 0x04),            // bit 2 - UV
+    	backupEligibility: Boolean(flags & 0x08),          // bit 3 - BE
+    	backupState: Boolean(flags & 0x10),             // bit 4 - BS
+    	attestedCredentialData: Boolean(flags & 0x40),  // bit 6 - AT
+    	extensionData: Boolean(flags & 0x80),           // bit 7 - ED
+    	rawFlagsByte: flags,
+  	};
+}
+
+export function parseAuthenticatorFlags(
+  input: Buffer | Uint8Array,
+  isAttestation: boolean
+): AuthenticatorFlags {
+  if (isAttestation) {
+    const decoded = cbor.decode(input);
+
+    if (!decoded.authData) {
+      throw new Error("Invalid attestationObject: missing authData");
+    }
+
+    return parseAuthenticatorFlagsFromAuthenticatorData(decoded.authData);
+  }
+
+  return parseAuthenticatorFlagsFromAuthenticatorData(input);
+}

--- a/src/webauthn.ts
+++ b/src/webauthn.ts
@@ -91,57 +91,51 @@ export function stripAttestationStatement(attObj: Buffer | Uint8Array): Buffer {
 
 type AuthenticatorFlags = {
 	userPresent: boolean;              // UP
-  	userVerified: boolean;             // UV
-  	backupEligibility: boolean;        // BE
-  	backupState: boolean;              // BS
-  	attestedCredentialData: boolean;   // AT
-  	extensionData: boolean;            // ED
-  	rawFlagsByte: number;
+	userVerified: boolean;             // UV
+	backupEligibility: boolean;        // BE
+	backupState: boolean;              // BS
+	attestedCredentialData: boolean;   // AT
+	extensionData: boolean;            // ED
+	rawFlagsByte: number;
 };
 
 function toUint8Array(value: Buffer | Uint8Array | ArrayBuffer): Uint8Array {
-  	if (value instanceof Uint8Array) {
-    	return value;
-  	}
-
-  	return new Uint8Array(value);
+	if (value instanceof Uint8Array) {
+		return value;
+	}
+	return new Uint8Array(value);
 }
 
-function parseAuthenticatorFlagsFromAuthenticatorData(
-  	authenticatorData: Buffer | Uint8Array | ArrayBuffer
-): AuthenticatorFlags {
-  	const data = toUint8Array(authenticatorData);
+function parseAuthenticatorFlagsFromAuthenticatorData(authenticatorData: Buffer | Uint8Array | ArrayBuffer): AuthenticatorFlags {
+	const data = toUint8Array(authenticatorData);
 
-  	if (data.length < 37) {
-    	throw new Error("Invalid authenticatorData: too short");
-  	}
+	if (data.length < 37) {
+		throw new Error("Invalid authenticatorData: too short");
+	}
 
-  	const flags = data[32];
+	const flags = data[32];
 
-  	return {
-    	userPresent: Boolean(flags & 0x01),             // bit 0 - UP
-    	userVerified: Boolean(flags & 0x04),            // bit 2 - UV
-    	backupEligibility: Boolean(flags & 0x08),          // bit 3 - BE
-    	backupState: Boolean(flags & 0x10),             // bit 4 - BS
-    	attestedCredentialData: Boolean(flags & 0x40),  // bit 6 - AT
-    	extensionData: Boolean(flags & 0x80),           // bit 7 - ED
-    	rawFlagsByte: flags,
-  	};
+	return {
+		userPresent: Boolean(flags & 0x01),             // bit 0 - UP
+		userVerified: Boolean(flags & 0x04),            // bit 2 - UV
+		backupEligibility: Boolean(flags & 0x08),          // bit 3 - BE
+		backupState: Boolean(flags & 0x10),             // bit 4 - BS
+		attestedCredentialData: Boolean(flags & 0x40),  // bit 6 - AT
+		extensionData: Boolean(flags & 0x80),           // bit 7 - ED
+		rawFlagsByte: flags,
+	};
 }
 
-export function parseAuthenticatorFlags(
-  input: Buffer | Uint8Array,
-  isAttestation: boolean
-): AuthenticatorFlags {
-  if (isAttestation) {
-    const decoded = cbor.decode(input);
+export function parseAuthenticatorFlags(input: Buffer | Uint8Array,isAttestation: boolean): AuthenticatorFlags {
+	if (isAttestation) {
+		const decoded = cbor.decode(input);
 
-    if (!decoded.authData) {
-      throw new Error("Invalid attestationObject: missing authData");
-    }
+		if (!decoded.authData) {
+			throw new Error("Invalid attestationObject: missing authData");
+		}
 
-    return parseAuthenticatorFlagsFromAuthenticatorData(decoded.authData);
-  }
+		return parseAuthenticatorFlagsFromAuthenticatorData(decoded.authData);
+	}
 
-  return parseAuthenticatorFlagsFromAuthenticatorData(input);
+	return parseAuthenticatorFlagsFromAuthenticatorData(input);
 }


### PR DESCRIPTION
Add the functionality that is described in issue https://github.com/wwWallet/wwwallet/issues/52 on the backend side.

### Note
The fields backupEligibility and backupState have been added in webauthn_credential table of wwwallet database. These fields store the values of ```BE``` and ```BS``` that are mentioned in the issue.

Database migration needed.