### PR TITLE
Add WebAuthn Signal API Support for Passkey Synchronization

### DIFF
--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -335,6 +335,19 @@ async function getUserByWebauthnCredential(userId: UserId, credentialId: Buffer)
 	}
 }
 
+async function hasWebauthnCredentialId(credentialId: Buffer): Promise<Result<boolean, GetUserErr>> {
+	try {
+		const count = await webauthnCredentialRepository.createQueryBuilder("credential")
+			.where("credential.credentialId = :credentialId", { credentialId })
+			.getCount();
+		return Ok(count > 0);
+	}
+	catch(e) {
+		console.log(e);
+		return Err(GetUserErr.DB_ERR);
+	}
+}
+
 async function getAllUsers(): Promise<Result<UserEntity[], GetUserErr>> {
 	try {
 
@@ -488,6 +501,7 @@ export {
 	getUser,
 	getUserByCredentials,
 	getUserByWebauthnCredential,
+	hasWebauthnCredentialId,
 	getAllUsers,
 	newWebauthnCredentialEntity,
 	updateUser,

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -331,7 +331,7 @@ async function getUserByWebauthnCredential(userId: UserId, credentialId: Buffer)
 	}
 	catch(e) {
 		console.log(e);
-		return Err(GetUserErr.NOT_EXISTS);
+		return Err(GetUserErr.DB_ERR);
 	}
 }
 

--- a/src/routers/user.router.ts
+++ b/src/routers/user.router.ts
@@ -6,7 +6,7 @@ import base64url from 'base64url';
 import { EntityManager } from "typeorm"
 
 import { config } from '../../config';
-import { CreateUser, createUser, deleteUser, deleteWebauthnCredential, getUserByCredentials, getUser, getUserByWebauthnCredential, GetUserErr, newWebauthnCredentialEntity, privateDataEtag, updateUser, UpdateUserErr, updateWebauthnCredential, updateWebauthnCredentialById, UserEntity, UserId } from '../entities/user.entity';
+import { CreateUser, createUser, deleteUser, deleteWebauthnCredential, getUserByCredentials, getUser, getUserByWebauthnCredential, GetUserErr, hasWebauthnCredentialId, newWebauthnCredentialEntity, privateDataEtag, updateUser, UpdateUserErr, updateWebauthnCredential, updateWebauthnCredentialById, UserEntity, UserId } from '../entities/user.entity';
 import { checkedUpdate, EtagUpdate, jsonParseTaggedBinary } from '../util/util';
 import { AuthMiddleware, createAppToken } from '../middlewares/auth.middleware';
 import { ChallengeErr, createChallenge, popChallenge } from '../entities/WebauthnChallenge.entity';
@@ -247,7 +247,14 @@ noAuthUserController.post('/login-webauthn-finish', async (req: Request, res: Re
 	const userRes = await getUserByWebauthnCredential(userId, credentialId);
 	if (userRes.err) {
 		if (userRes.val === GetUserErr.NOT_EXISTS) {
-			res.status(403).send({});
+			const credentialExistsRes = await hasWebauthnCredentialId(credentialId);
+			if (credentialExistsRes.err) {
+				res.status(500).send({});
+			} else if (credentialExistsRes.val) {
+				res.status(403).send({});
+			} else {
+				res.status(403).send({ error: "UNKNOWN_WEBAUTHN_CREDENTIAL" });
+			}
 		} else {
 			res.status(500).send({});
 		}

--- a/src/routers/user.router.ts
+++ b/src/routers/user.router.ts
@@ -246,7 +246,11 @@ noAuthUserController.post('/login-webauthn-finish', async (req: Request, res: Re
 
 	const userRes = await getUserByWebauthnCredential(userId, credentialId);
 	if (userRes.err) {
-		res.status(403).send({});
+		if (userRes.val === GetUserErr.NOT_EXISTS) {
+			res.status(403).send({});
+		} else {
+			res.status(500).send({});
+		}
 		return;
 	}
 	const [user, credentialRecord] = userRes.unwrap();


### PR DESCRIPTION
Adds the functionality that is described in issue https://github.com/wwWallet/wwwallet/issues/54 on the backend server.

The backend server is involved only in the case of the deletion of an unknown credential, upon failed login, during the authentication ceremony. The functionality is described in the respective issue.

In order to determine whether a credential is unknown(upon authentication), the backend server checks if the credentialId exists in the database. Only in the case of a successful search that did not return the credential (corresponding to the credentialId) the signalUnkownCredential() method should be triggered. Any other case of failed login (i.e. a database connection failure) must not trigger the signal method.