### PR TITLE
Change nickName to name in Webauthn Credential display

### DIFF
--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -142,7 +142,7 @@ class WebauthnCredentialEntity {
 
 	// Explicit default to workaround a bug in typeorm: https://github.com/typeorm/typeorm/issues/3076#issuecomment-703128687
 	@Column({ nullable: true, default: () => "NULL" })
-	nickname: string;
+	name: string;
 
 	@Column({ type: "datetime", nullable: false, update: false })
 	createTime: Date;

--- a/src/migrations/1783665579645-RenameNickNameToWebauthnCredential.ts
+++ b/src/migrations/1783665579645-RenameNickNameToWebauthnCredential.ts
@@ -1,12 +1,11 @@
 import { MigrationInterface, QueryRunner } from "typeorm";
 
-export class RenameNickNameToWebauthnCredential implements MigrationInterface {
-
+export class RenameNickNameToWebauthnCredential1783665579645 implements MigrationInterface {
 	public async up(queryRunner: QueryRunner): Promise<void> {
-		await queryRunner.query(`ALTER TABLE \'webauthn_credential\' RENAME COLUMN \'nickname\' TO \'name\';`);
+		await queryRunner.query(`ALTER TABLE webauthn_credential RENAME COLUMN nickname TO name;`);
 	}
 
 	public async down(queryRunner: QueryRunner): Promise<void> {
-		await queryRunner.query(`ALTER TABLE \'webauthn_credential\' RENAME COLUMN \'name\' TO \'nickname\';`);
+		await queryRunner.query(`ALTER TABLE webauthn_credential RENAME COLUMN name TO nickname;`);
 	}
 }

--- a/src/migrations/1783665579645-RenameNickNameToWebauthnCredential.ts
+++ b/src/migrations/1783665579645-RenameNickNameToWebauthnCredential.ts
@@ -1,0 +1,12 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class RenameNickNameToWebauthnCredential implements MigrationInterface {
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(`ALTER TABLE \'webauthn_credential\' RENAME COLUMN \'nickname\' TO \'name\';`);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(`ALTER TABLE \'webauthn_credential\' RENAME COLUMN \'name\' TO \'nickname\';`);
+	}
+}

--- a/src/routers/user.router.ts
+++ b/src/routers/user.router.ts
@@ -171,7 +171,7 @@ if (!config.registerDisabled) {
 					newWebauthnCredentialEntity({
 						credentialId: credential.rawId,
 						_userHandle: challenge.userId.asUserHandle(),
-						nickname: req.body.nickname,
+						name: req.body.name,
 						publicKeyCose: Buffer.from(verification.registrationInfo.credentialPublicKey),
 						signatureCount: verification.registrationInfo.counter,
 						transports: credential.response.transports || [],
@@ -334,7 +334,7 @@ userController.get('/account-info', async (req: Request, res: Response) => {
 			credentialId: cred.credentialId,
 			id: cred.id,
 			lastUseTime: cred.lastUseTime,
-			nickname: cred.nickname,
+			name: cred.name,
 			prfCapable: cred.prfCapable,
 			backupEligibility: cred.backupEligibility,
 			backupState: cred.backupState,
@@ -435,7 +435,7 @@ userController.post('/webauthn/register-finish', async (req: Request, res: Respo
 				newWebauthnCredentialEntity({
 					credentialId: Buffer.from(verification.registrationInfo.credentialID),
 					_userHandle: user.uuid.asUserHandle(),
-					nickname: req.body.nickname,
+					name: req.body.name,
 					publicKeyCose: Buffer.from(verification.registrationInfo.credentialPublicKey),
 					signatureCount: verification.registrationInfo.counter,
 					transports: credential.response.transports || [],
@@ -485,7 +485,7 @@ userController.post('/webauthn/credential/:id/rename', async (req: Request, res:
 	console.log("webauthn rename", req.params.id);
 
 	const updateRes = await updateWebauthnCredentialById(req.user.id, req.params.id, (credentialEntity, manager) => {
-		credentialEntity.nickname = req.body.nickname || null;
+		credentialEntity.name = req.body.name || null;
 		return credentialEntity;
 	});
 

--- a/src/routers/user.router.ts
+++ b/src/routers/user.router.ts
@@ -87,6 +87,8 @@ if (!config.registerDisabled) {
 	});
 
 	noAuthUserController.post('/register-webauthn-begin', async (req: Request, res: Response) => {
+		const displayName = typeof req.body.displayName === "string" ? req.body.displayName : "";
+		const name = typeof req.body.name === "string" ? req.body.name : displayName;
 		const userId = UserId.generate();
 		const challengeRes = await createChallenge("create", userId);
 		if (challengeRes.err) {
@@ -99,8 +101,8 @@ if (!config.registerDisabled) {
 			challenge: challenge.challenge,
 			user: {
 				uuid: userId,
-				name: "",
-				displayName: "",
+				name: name,
+				displayName: displayName,
 			},
 		});
 
@@ -164,6 +166,7 @@ if (!config.registerDisabled) {
 			}
 			var flags = webauthn.parseAuthenticatorFlags(credential.response.attestationObject, true);
 
+			const credentialName =typeof req.body.name === "string" && req.body.nname? req.body.name: (typeof req.body.displayName === "string" && req.body.displayName? req.body.displayName: null);
 			const newUser: CreateUser = {
 				...walletInitializationResult.unwrap(),
 				uuid: challenge.userId,
@@ -171,7 +174,7 @@ if (!config.registerDisabled) {
 					newWebauthnCredentialEntity({
 						credentialId: credential.rawId,
 						_userHandle: challenge.userId.asUserHandle(),
-						name: req.body.name,
+						name: credentialName,
 						publicKeyCose: Buffer.from(verification.registrationInfo.credentialPublicKey),
 						signatureCount: verification.registrationInfo.counter,
 						transports: credential.response.transports || [],


### PR DESCRIPTION
Add the functionality that is described in issue https://github.com/wwWallet/wwwallet/issues/55 on the backend side.

### Note

The field ```nickname``` has been renamed to ```name``` in ```webauthn_credential``` table of ```wallet``` database.

Database migration needed.