### PR TITLE
Adding AAGUID to webauthnCredential

### DIFF
--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -174,6 +174,9 @@ class WebauthnCredentialEntity {
 	@Column({ nullable: false })
 	backupState: boolean;
 
+	@Column({ type: "varchar", length: 36, nullable: true })
+	aaguid: string;
+
 	getCredentialDescriptor() {
 		return {
 			type: "public-key",

--- a/src/migrations/1784883771538-AddAaguidToWebauthn.ts
+++ b/src/migrations/1784883771538-AddAaguidToWebauthn.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddAaguidToWebauthn1784883771538 implements MigrationInterface {
+		name = 'AddAaguidToWebauthn1784883771538'
+
+		public async up(queryRunner: QueryRunner): Promise<void> {
+				await queryRunner.query(`ALTER TABLE \`webauthn_credential\` CHANGE \`aaguid\` \`aaguid\` varchar(36) NULL`);
+		}
+
+		public async down(queryRunner: QueryRunner): Promise<void> {
+				await queryRunner.query(`ALTER TABLE \`webauthn_credential\` CHANGE \`aaguid\` \`aaguid\` varchar(36) NULL DEFAULT 'NULL'`);
+		}
+
+}

--- a/src/routers/user.router.ts
+++ b/src/routers/user.router.ts
@@ -179,7 +179,8 @@ if (!config.registerDisabled) {
 						create_clientDataJSON: credential.response.clientDataJSON,
 						prfCapable: credential.clientExtensionResults?.prf?.enabled || false,
 						backupEligibility: flags.backupEligibility,
-						backupState: flags.backupState
+						backupState: flags.backupState,
+						aaguid: verification.registrationInfo?.aaguid || null
 					}),
 				],
 			};
@@ -338,6 +339,7 @@ userController.get('/account-info', async (req: Request, res: Response) => {
 			prfCapable: cred.prfCapable,
 			backupEligibility: cred.backupEligibility,
 			backupState: cred.backupState,
+			aaguid: cred.aaguid,
 		})),
 	});
 })
@@ -443,7 +445,8 @@ userController.post('/webauthn/register-finish', async (req: Request, res: Respo
 					create_clientDataJSON: Buffer.from(credential.response.clientDataJSON),
 					prfCapable: credential.clientExtensionResults?.prf?.enabled || false,
 					backupEligibility: flags.backupEligibility,
-					backupState: flags.backupState
+					backupState: flags.backupState,
+					aaguid: verification.registrationInfo?.aaguid || null
 				}, manager)
 			);
 


### PR DESCRIPTION
### Description
---
Related to wwWallet/wwwallet#56

In order to lay the groundwork for incorporating FIDO MDS3, we need to capture and store the AAGUID (Authenticator Attestation Globally Unique Identifier) for user authenticators. As discussed in the issue, this PR extracts the AAGUID from the authenticator's attestation statement during the initial WebAuthn credential registration and saves it to the database.

### Changes made
---
1. Entity Update: Added a nullable aaguid column to the WebauthnCredential entity.
2. Migration: Generated the corresponding TypeORM migration file to safely update the schema.
3. Router Update: Modified the registration endpoints in user.router.ts to extract the aaguid from the verified registration info and save it to the database.
4. Account Info: Exposed the aaguid in the /account-info response mapping.